### PR TITLE
feat(adios): Meta Ads conversion attribution + historical backfill

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,9 @@ import PackDetailPage from "@/pages/PackDetailPage";
 // Routing guards
 import CompanySlugGuard from "@/components/routing/CompanySlugGuard";
 
+// Hooks
+import { useUtmCapture } from "@/hooks/useUtmCapture";
+
 // Admin pages
 import Dashboard from "@/pages/Dashboard";
 import AdminChatPage from "@/pages/AdminChatPage";
@@ -165,7 +168,12 @@ const queryClient = new QueryClient({
 });
 
 // Main App Routes component
-const AppRoutes = () => (
+const AppRoutes = () => {
+  // Capture UTM / fbclid params on landing for Meta Ads attribution (AdiOS).
+  // Idempotent — only persists when real attribution params are in the URL.
+  useUtmCapture();
+
+  return (
   <Routes>
     {/* AUTHENTICATION ROUTES - HIGHEST PRIORITY */}
     <Route path="/login" element={<Login />} />
@@ -379,7 +387,8 @@ const AppRoutes = () => (
     {/* Catch-all company slug route - fallback for company pages */}
     <Route path="/:companySlug" element={<CompanySlugGuard />} />
   </Routes>
-);
+  );
+};
 
 function App() {
   console.log('🚀 App component rendering...');

--- a/src/components/settings/AdiOSIntegrationCard.tsx
+++ b/src/components/settings/AdiOSIntegrationCard.tsx
@@ -1,0 +1,538 @@
+import React, { useState, useEffect } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Separator } from "@/components/ui/separator";
+import {
+  Megaphone,
+  CheckCircle2,
+  AlertCircle,
+  RefreshCw,
+  Send,
+  Save,
+  ExternalLink,
+  Wifi,
+  WifiOff,
+  History,
+  Eye,
+} from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
+import { toast } from "sonner";
+import { testAdiOSWebhook, backfillAdiOSHistorical, type AdiOSBackfillResult } from "@/utils/adios";
+
+interface AdiOSConfig {
+  id: string;
+  webhook_url: string;
+  enabled_events: string[];
+  is_active: boolean;
+  last_triggered_at: string | null;
+  last_status: string | null;
+  last_error: string | null;
+}
+
+export default function AdiOSIntegrationCard() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [backfilling, setBackfilling] = useState(false);
+  const [lastBackfill, setLastBackfill] = useState<AdiOSBackfillResult | null>(null);
+
+  const [config, setConfig] = useState<AdiOSConfig | null>(null);
+  const [webhookUrl, setWebhookUrl] = useState("");
+  const [isActive, setIsActive] = useState(true);
+  const [companyId, setCompanyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchConfig();
+  }, []);
+
+  const fetchConfig = async () => {
+    try {
+      setLoading(true);
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session) {
+        setLoading(false);
+        return;
+      }
+
+      const { data: profile } = await supabase
+        .from("profiles")
+        .select("company_id")
+        .eq("id", session.user.id)
+        .single();
+
+      if (!profile?.company_id) {
+        setLoading(false);
+        return;
+      }
+      setCompanyId(profile.company_id);
+
+      const { data: adiosConfig, error } = await supabase
+        .from("adios_integrations" as any)
+        .select("*")
+        .eq("company_id", profile.company_id)
+        .maybeSingle();
+
+      if (error && (error as any).code !== "PGRST116") {
+        console.error("Error fetching AdiOS config:", error);
+        return;
+      }
+      if (adiosConfig) {
+        const cfg = adiosConfig as any;
+        setConfig(cfg);
+        setWebhookUrl(cfg.webhook_url || "");
+        setIsActive(cfg.is_active);
+      }
+    } catch (error) {
+      console.error("Error:", error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const validateUrl = (url: string): string | null => {
+    if (!url.trim()) return "Veuillez entrer l'URL du webhook AdiOS";
+    try {
+      const parsed = new URL(url);
+      if (parsed.protocol !== "https:") return "L'URL doit commencer par https://";
+      if (!parsed.hostname.includes("adios.pub") && !parsed.hostname.includes("adios.")) {
+        return "L'URL ne semble pas être un webhook AdiOS";
+      }
+    } catch {
+      return "URL invalide";
+    }
+    return null;
+  };
+
+  const handleSave = async () => {
+    const err = validateUrl(webhookUrl);
+    if (err) {
+      toast.error(err);
+      return;
+    }
+    if (!companyId) {
+      toast.error("Erreur: Company ID manquant");
+      return;
+    }
+
+    try {
+      setSaving(true);
+      const configData: any = {
+        company_id: companyId,
+        webhook_url: webhookUrl.trim(),
+        enabled_events: ["contract_signed"],
+        is_active: isActive,
+      };
+
+      if (config?.id) {
+        const { error } = await supabase
+          .from("adios_integrations" as any)
+          .update(configData)
+          .eq("id", config.id);
+        if (error) throw error;
+      } else {
+        const { data, error } = await supabase
+          .from("adios_integrations" as any)
+          .insert(configData)
+          .select()
+          .single();
+        if (error) throw error;
+        setConfig(data as any);
+      }
+
+      toast.success("Configuration AdiOS sauvegardée");
+      await fetchConfig();
+    } catch (error) {
+      console.error("Error saving AdiOS config:", error);
+      toast.error("Erreur lors de la sauvegarde");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleBackfill = async (dryRun: boolean) => {
+    if (!config?.id || !config.is_active || !config.webhook_url) {
+      toast.error("Configurez et activez AdiOS avant de lancer le backfill");
+      return;
+    }
+
+    if (!dryRun) {
+      const ok = window.confirm(
+        "Cela va envoyer toutes les conversions Meta historiques (contrats signés non encore synchronisés) à AdiOS.\n\n" +
+        "Action idempotente : chaque offre n'est envoyée qu'une seule fois.\n\n" +
+        "Continuer ?",
+      );
+      if (!ok) return;
+    }
+
+    try {
+      setBackfilling(true);
+      setLastBackfill(null);
+      const result = await backfillAdiOSHistorical({
+        dry_run: dryRun,
+        max_to_send: 200,
+        delay_between_ms: 250,
+      });
+      setLastBackfill(result);
+
+      if (!result.success) {
+        toast.error(
+          <div>
+            <strong>Backfill échoué</strong>
+            <p className="text-sm mt-1">{result.error || "Erreur inconnue"}</p>
+          </div>,
+        );
+        return;
+      }
+
+      if (dryRun) {
+        toast.info(
+          <div>
+            <strong>Aperçu (dry-run)</strong>
+            <p className="text-sm mt-1">
+              {result.sent} conversion(s) prêtes à envoyer · {result.skipped_not_meta} non-Meta ignorée(s)
+            </p>
+          </div>,
+          { duration: 6000 },
+        );
+      } else {
+        toast.success(
+          <div>
+            <strong>Backfill terminé</strong>
+            <p className="text-sm mt-1">
+              {result.sent} envoyé(s) · {result.skipped_not_meta} ignoré(s) (non Meta)
+              {result.errors > 0 ? ` · ${result.errors} erreur(s)` : ""}
+            </p>
+          </div>,
+          { duration: 8000 },
+        );
+        await fetchConfig(); // refresh last_triggered_at
+      }
+    } catch (err) {
+      console.error("Error in backfill:", err);
+      toast.error("Erreur inattendue pendant le backfill");
+    } finally {
+      setBackfilling(false);
+    }
+  };
+
+  const handleTest = async () => {
+    const err = validateUrl(webhookUrl);
+    if (err) {
+      toast.error(err);
+      return;
+    }
+
+    try {
+      setTesting(true);
+      const result = await testAdiOSWebhook(webhookUrl.trim());
+      if (result.success) {
+        toast.success(
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-green-500" />
+            <span>{result.message}</span>
+          </div>,
+          { duration: 5000 },
+        );
+      } else {
+        toast.error(
+          <div>
+            <strong>Échec du test</strong>
+            <p className="text-sm mt-1">{result.message}</p>
+            {result.status && (
+              <p className="text-xs text-muted-foreground">Code HTTP: {result.status}</p>
+            )}
+          </div>,
+          { duration: 8000 },
+        );
+      }
+    } catch (error) {
+      console.error("Error testing AdiOS webhook:", error);
+      toast.error("Erreur inattendue lors du test");
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const formatDate = (s?: string | null) => {
+    if (!s) return "Jamais";
+    return new Date(s).toLocaleString("fr-FR", {
+      day: "2-digit", month: "2-digit", year: "numeric",
+      hour: "2-digit", minute: "2-digit",
+    });
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Megaphone className="h-5 w-5" />
+            AdiOS
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8">
+            <RefreshCw className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="p-2 bg-purple-100 rounded-lg">
+              <Megaphone className="h-5 w-5 text-purple-600" />
+            </div>
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                AdiOS
+                {config?.is_active && config?.webhook_url && (
+                  <Badge className="bg-primary/20 text-primary hover:bg-primary/20">
+                    <Wifi className="h-3 w-3 mr-1" />
+                    Connecté
+                  </Badge>
+                )}
+              </CardTitle>
+              <CardDescription>
+                Suivi des conversions Meta Ads (Facebook & Instagram)
+              </CardDescription>
+            </div>
+          </div>
+          <Button variant="ghost" size="icon" asChild>
+            <a href="https://app.adios.pub/app/conversions" target="_blank" rel="noopener noreferrer">
+              <ExternalLink className="h-4 w-4" />
+            </a>
+          </Button>
+        </div>
+      </CardHeader>
+
+      <CardContent className="space-y-6">
+        {/* Connection status */}
+        <div className="flex items-center gap-2 text-sm">
+          {config?.webhook_url ? (
+            <>
+              <Wifi className="h-4 w-4 text-primary" />
+              <span className="text-muted-foreground">Webhook configuré</span>
+            </>
+          ) : (
+            <>
+              <WifiOff className="h-4 w-4 text-muted-foreground" />
+              <span className="text-muted-foreground">Non configuré</span>
+            </>
+          )}
+        </div>
+
+        {/* Webhook URL */}
+        <div className="space-y-2">
+          <Label htmlFor="adios-webhook-url">URL du Webhook AdiOS</Label>
+          <Input
+            id="adios-webhook-url"
+            type="url"
+            placeholder="https://app.adios.pub/api/webhooks/conversions/..."
+            value={webhookUrl}
+            onChange={(e) => setWebhookUrl(e.target.value)}
+          />
+          <p className="text-xs text-muted-foreground">
+            Dans AdiOS → <em>Brancher Leazr (ou un autre CRM)</em>, copiez l'URL
+            du webhook actif et collez-la ici.
+          </p>
+        </div>
+
+        {/* Active toggle */}
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <Label htmlFor="adios-active">Intégration active</Label>
+            <p className="text-xs text-muted-foreground">
+              Quand un contrat issu de Facebook ou Instagram est signé, la
+              conversion est envoyée à AdiOS automatiquement.
+            </p>
+          </div>
+          <Switch
+            id="adios-active"
+            checked={isActive}
+            onCheckedChange={setIsActive}
+          />
+        </div>
+
+        <Separator />
+
+        {/* How it works */}
+        <Alert>
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription className="text-sm space-y-1">
+            <p className="font-medium">Comment ça marche</p>
+            <p>
+              Quand un lead arrivé via une <strong>publicité Meta</strong>{" "}
+              (Facebook ou Instagram) signe son contrat, Leazr envoie
+              automatiquement la conversion à AdiOS avec la plateforme
+              d'origine, l'email et la valeur totale du contrat (mensualité ×
+              durée).
+            </p>
+            <p className="text-xs text-muted-foreground pt-1">
+              Détection de la source par ordre de priorité : (1) leads importés
+              via <code>import-meta-leads</code> (plateforme connue), (2) liens
+              UTM <code>utm_source=facebook|instagram</code> ou{" "}
+              <code>fbclid</code> capturés sur les pages publiques, (3) mention
+              "Plateforme: Facebook/Instagram" dans les remarques de l'offre ou
+              les notes du client.
+            </p>
+          </AlertDescription>
+        </Alert>
+
+        {/* Historical backfill */}
+        {config?.id && config.is_active && (
+          <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
+            <div className="flex items-start gap-2">
+              <History className="h-4 w-4 mt-0.5 text-purple-600" />
+              <div className="flex-1">
+                <h4 className="text-sm font-medium">Importer l'historique Meta</h4>
+                <p className="text-xs text-muted-foreground mt-1">
+                  Renvoie toutes les conversions Meta passées (contrats déjà
+                  signés non encore poussés) vers AdiOS pour calculer la
+                  rentabilité de tes campagnes existantes. Idempotent — chaque
+                  conversion n'est envoyée qu'une fois.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handleBackfill(true)}
+                disabled={backfilling}
+                className="flex-1"
+              >
+                {backfilling ? (
+                  <RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" />
+                ) : (
+                  <Eye className="h-3.5 w-3.5 mr-2" />
+                )}
+                Aperçu (dry-run)
+              </Button>
+              <Button
+                size="sm"
+                onClick={() => handleBackfill(false)}
+                disabled={backfilling}
+                className="flex-1"
+              >
+                {backfilling ? (
+                  <RefreshCw className="h-3.5 w-3.5 mr-2 animate-spin" />
+                ) : (
+                  <History className="h-3.5 w-3.5 mr-2" />
+                )}
+                Lancer le backfill
+              </Button>
+            </div>
+
+            {lastBackfill && (
+              <div className="text-xs space-y-1 pt-2 border-t border-border/50">
+                <div className="font-medium">
+                  {lastBackfill.dry_run ? "Aperçu" : "Dernier backfill"}
+                  {lastBackfill.success ? "" : " (échec)"}
+                </div>
+                <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 text-muted-foreground">
+                  <span>Candidats trouvés:</span>
+                  <span className="text-foreground">{lastBackfill.total_candidates}</span>
+                  <span>{lastBackfill.dry_run ? "À envoyer:" : "Envoyés:"}</span>
+                  <span className="text-foreground">{lastBackfill.sent}</span>
+                  <span>Non-Meta ignorés:</span>
+                  <span className="text-foreground">{lastBackfill.skipped_not_meta}</span>
+                  {lastBackfill.skipped_already_synced > 0 && (
+                    <>
+                      <span>Déjà synchronisés:</span>
+                      <span className="text-foreground">{lastBackfill.skipped_already_synced}</span>
+                    </>
+                  )}
+                  {lastBackfill.errors > 0 && (
+                    <>
+                      <span className="text-destructive">Erreurs:</span>
+                      <span className="text-destructive">{lastBackfill.errors}</span>
+                    </>
+                  )}
+                </div>
+                {lastBackfill.error_details && lastBackfill.error_details.length > 0 && (
+                  <details className="mt-2">
+                    <summary className="cursor-pointer text-destructive">
+                      Voir les erreurs
+                    </summary>
+                    <ul className="mt-1 space-y-0.5 pl-4 list-disc">
+                      {lastBackfill.error_details.slice(0, 5).map((e, i) => (
+                        <li key={i} className="text-destructive">
+                          {e.error}
+                        </li>
+                      ))}
+                    </ul>
+                  </details>
+                )}
+                {lastBackfill.sent >= 200 && (
+                  <p className="text-amber-600 mt-1">
+                    ⚠️ Maximum atteint (200 par appel). Relance le backfill
+                    pour traiter le reste.
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Last triggered */}
+        {config?.last_triggered_at && (
+          <div className="space-y-2 text-sm">
+            <div className="flex items-center justify-between">
+              <span className="text-muted-foreground">Dernier envoi:</span>
+              <span>{formatDate(config.last_triggered_at)}</span>
+            </div>
+            {config.last_status && (
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Statut:</span>
+                <Badge variant={config.last_status === "success" ? "default" : "destructive"}>
+                  {config.last_status === "success" ? "Succès" : "Erreur"}
+                </Badge>
+              </div>
+            )}
+            {config.last_status === "error" && config.last_error && (
+              <p className="text-xs text-destructive bg-destructive/10 rounded p-2">
+                {config.last_error}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            className="flex-1"
+            onClick={handleTest}
+            disabled={testing || !webhookUrl.trim()}
+          >
+            {testing ? (
+              <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4 mr-2" />
+            )}
+            Tester le webhook
+          </Button>
+          <Button className="flex-1" onClick={handleSave} disabled={saving}>
+            {saving ? (
+              <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
+            ) : (
+              <Save className="h-4 w-4 mr-2" />
+            )}
+            Sauvegarder
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/settings/IntegrationsManager.tsx
+++ b/src/components/settings/IntegrationsManager.tsx
@@ -3,10 +3,11 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import { Settings, ExternalLink, Zap, Building2, Calculator, FileText, Users, CreditCard, Shield, Mail, Database, ShoppingCart } from 'lucide-react';
+import { Settings, ExternalLink, Zap, Building2, Calculator, FileText, Users, CreditCard, Shield, Mail, Database, ShoppingCart, Megaphone } from 'lucide-react';
 import CompanyWebIntegrationSettings from './CompanyWebIntegrationSettings';
 import WooCommerceConfigurationManager from './WooCommerceConfigurationManager';
 import ZapierIntegrationCard from './ZapierIntegrationCard';
+import AdiOSIntegrationCard from './AdiOSIntegrationCard';
 
 interface Integration {
   id: string;
@@ -19,6 +20,16 @@ interface Integration {
 }
 
 const integrations: Integration[] = [
+  // Marketing
+  {
+    id: 'adios',
+    name: 'AdiOS',
+    description: 'Suivi des conversions Meta Ads (Facebook & Instagram)',
+    logoUrl: 'https://app.adios.pub/favicon.ico',
+    status: 'available',
+    category: 'Marketing'
+  },
+
   // Automation
   {
     id: 'zapier',
@@ -406,6 +417,8 @@ const getCategoryIcon = (category: string) => {
       return <CreditCard className="h-6 w-6 text-emerald-600" />;
     case 'RH & Paie':
       return <CreditCard className="h-6 w-6 text-pink-600" />;
+    case 'Marketing':
+      return <Megaphone className="h-6 w-6 text-purple-600" />;
     default:
       return <Database className="h-6 w-6 text-gray-600" />;
   }
@@ -566,8 +579,12 @@ const IntegrationsManager = () => {
             {selectedIntegration === 'zapier' && (
               <ZapierIntegrationCard />
             )}
-            
-            {selectedIntegration && !['woocommerce', 'companyweb', 'zapier'].includes(selectedIntegration) && (
+
+            {selectedIntegration === 'adios' && (
+              <AdiOSIntegrationCard />
+            )}
+
+            {selectedIntegration && !['woocommerce', 'companyweb', 'zapier', 'adios'].includes(selectedIntegration) && (
               <div className="text-center py-8">
                 <Settings className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
                 <h3 className="text-lg font-semibold mb-2">Configuration à venir</h3>

--- a/src/hooks/useUtmCapture.ts
+++ b/src/hooks/useUtmCapture.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+import { captureAttribution } from "@/utils/utmAttribution";
+
+/**
+ * Capture UTM / fbclid params on mount and persist them to sessionStorage.
+ *
+ * Mount this near the root of public landing routes (catalog, slug pages, …).
+ * It's safe to call multiple times — capture is idempotent and only overwrites
+ * when a fresh campaign click arrives.
+ */
+export function useUtmCapture() {
+  useEffect(() => {
+    captureAttribution();
+  }, []);
+}

--- a/src/pages/client/PublicContractSignature.tsx
+++ b/src/pages/client/PublicContractSignature.tsx
@@ -25,10 +25,11 @@ import SignatureCanvas from "react-signature-canvas";
 import IBANInput from "@/components/contracts/IBANInput";
 import { pdf } from '@react-pdf/renderer';
 import { SignedContractPDFDocument } from '@/components/pdf/templates/SignedContractPDFDocument';
-import { 
-  buildSignedContractPdfDataFromRpc, 
-  getSignedContractStoragePath 
+import {
+  buildSignedContractPdfDataFromRpc,
+  getSignedContractStoragePath
 } from '@/services/signedContractPdfPublicData';
+import { notifyAdiOSContractSigned } from '@/utils/adios';
 
 interface ContractData {
   id: string;
@@ -427,6 +428,10 @@ const PublicContractSignature: React.FC = () => {
       if (data?.success) {
         setIsSigned(true);
         toast.success("Contrat signé avec succès !");
+
+        // Notify AdiOS for Meta Ads conversion attribution (fire-and-forget,
+        // server decides whether the lead is Meta-attributed and bails if not).
+        notifyAdiOSContractSigned(token);
 
         // Generate and store PDF (non-blocking)
         generateAndStorePdf().then(success => {

--- a/src/services/requestInfoService.ts
+++ b/src/services/requestInfoService.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { v4 as uuidv4 } from "uuid";
 import { createClientRequest } from "@/services/offers/clientRequests";
 import { supabase, getAdminSupabaseClient } from "@/integrations/supabase/client";
+import { readStoredAttribution } from "@/utils/utmAttribution";
 
 export interface ProductRequestData {
   client_name: string;
@@ -151,6 +152,13 @@ export const createProductRequest = async (data: ProductRequestData, cartItems?:
         city: data.shipping_city || '',
         country: (data.shipping_country || 'BE').substring(0, 2),
       };
+    }
+
+    // Forward stored UTM / fbclid attribution (Meta Ads → AdiOS pipeline).
+    // Captured on landing by useUtmCapture, persisted in sessionStorage.
+    const attribution = readStoredAttribution();
+    if (attribution) {
+      structuredData.attribution = attribution;
     }
 
     console.log("Calling Edge function create-product-request with structured data");

--- a/src/utils/adios.ts
+++ b/src/utils/adios.ts
@@ -1,0 +1,155 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * AdiOS — Meta Ads conversion attribution.
+ *
+ * The actual webhook delivery, source detection, and payload construction
+ * happen server-side in the `adios-proxy` edge function. These helpers are
+ * thin wrappers used by the settings UI and the public signing page.
+ */
+
+export interface AdiOSTestResult {
+  success: boolean;
+  message: string;
+  status?: number;
+}
+
+/**
+ * Test an AdiOS webhook URL from the settings page. The user must be
+ * authenticated.
+ */
+export async function testAdiOSWebhook(
+  webhookUrl: string,
+): Promise<AdiOSTestResult> {
+  try {
+    const { data, error } = await supabase.functions.invoke("adios-proxy", {
+      body: {
+        action: "test",
+        webhook_url: webhookUrl,
+        payload: {
+          external_id: `leazr-test-${Date.now()}`,
+          email: "test@leazr.co",
+          status: "won",
+          value_eur: 0,
+          occurred_at: new Date().toISOString(),
+          notes: "Test de connexion AdiOS depuis Leazr",
+        },
+      },
+    });
+
+    if (error) {
+      console.error("[AdiOS] Edge function error:", error);
+      return { success: false, message: error.message || "Erreur de connexion" };
+    }
+    return {
+      success: data?.success === true,
+      message: data?.message || data?.error || "Réponse inattendue",
+      status: data?.status,
+    };
+  } catch (err) {
+    console.error("[AdiOS] Test error:", err);
+    return { success: false, message: "Erreur inattendue lors du test" };
+  }
+}
+
+export interface AdiOSBackfillResult {
+  success: boolean;
+  dry_run?: boolean;
+  total_candidates: number;
+  sent: number;
+  skipped_not_meta: number;
+  skipped_already_synced: number;
+  errors: number;
+  error_details: Array<{ contract_id: string; error: string }>;
+  details: Array<{ contract_id: string; offer_id: string; platform: string; value_eur: number }>;
+  error?: string;
+}
+
+/**
+ * Backfill historical Meta-attributed signed contracts to AdiOS.
+ *
+ * Idempotent — uses offers.adios_synced_at as the watermark, so re-running
+ * this only picks up rows that haven't been pushed yet. Throttled server-side
+ * to avoid bombarding AdiOS.
+ *
+ * Pass dry_run=true to preview without actually sending.
+ */
+export async function backfillAdiOSHistorical(opts?: {
+  dry_run?: boolean;
+  max_to_send?: number;
+  delay_between_ms?: number;
+}): Promise<AdiOSBackfillResult> {
+  try {
+    const { data, error } = await supabase.functions.invoke("adios-proxy", {
+      body: {
+        action: "backfill",
+        dry_run: opts?.dry_run === true,
+        max_to_send: opts?.max_to_send,
+        delay_between_ms: opts?.delay_between_ms,
+      },
+    });
+
+    if (error) {
+      console.error("[AdiOS] Backfill edge error:", error);
+      return {
+        success: false,
+        total_candidates: 0,
+        sent: 0,
+        skipped_not_meta: 0,
+        skipped_already_synced: 0,
+        errors: 0,
+        error_details: [],
+        details: [],
+        error: error.message || "Erreur du backfill",
+      };
+    }
+
+    return data as AdiOSBackfillResult;
+  } catch (err) {
+    console.error("[AdiOS] Backfill threw:", err);
+    return {
+      success: false,
+      total_candidates: 0,
+      sent: 0,
+      skipped_not_meta: 0,
+      skipped_already_synced: 0,
+      errors: 0,
+      error_details: [],
+      details: [],
+      error: err instanceof Error ? err.message : "Erreur inattendue",
+    };
+  }
+}
+
+/**
+ * Fire the AdiOS conversion webhook from the public contract signing flow.
+ *
+ * Anonymous-safe: the edge function authenticates via the signature_token,
+ * loads the contract / offer / client server-side, detects whether the lead
+ * came from Meta, and only sends to AdiOS if it did. Fully best-effort —
+ * NEVER awaits / throws into the signing UX.
+ */
+export async function notifyAdiOSContractSigned(signatureToken: string): Promise<void> {
+  try {
+    const { data, error } = await supabase.functions.invoke("adios-proxy", {
+      body: {
+        action: "sign_contract",
+        signature_token: signatureToken,
+      },
+    });
+    if (error) {
+      console.warn("[AdiOS] notifyContractSigned edge error:", error.message);
+      return;
+    }
+    if (data?.success) {
+      console.log("[AdiOS] Conversion sent successfully");
+    } else if (data?.skipped) {
+      // Not Meta-attributed, not configured, or event disabled — nothing to do.
+      console.log("[AdiOS] Skipped:", data?.reason || data?.error);
+    } else {
+      console.warn("[AdiOS] Conversion failed:", data?.error);
+    }
+  } catch (err) {
+    console.warn("[AdiOS] notifyContractSigned threw:", err);
+  }
+}

--- a/src/utils/utmAttribution.ts
+++ b/src/utils/utmAttribution.ts
@@ -1,0 +1,119 @@
+/**
+ * UTM / ad-click attribution capture.
+ *
+ * Marketing ads (Meta, Google, …) land users on /:companySlug/... with query
+ * params like utm_source=facebook, utm_campaign=spring-2026, fbclid=…
+ *
+ * Capture happens once on landing, persists to sessionStorage, and travels
+ * with the user through the multi-step funnel (catalog → cart → /demande)
+ * until the offer is created. The values are then forwarded to the
+ * create-product-request edge function and stored on the offer row.
+ */
+export interface AttributionData {
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  utm_campaign?: string | null;
+  utm_content?: string | null;
+  utm_term?: string | null;
+  fbclid?: string | null;
+  landing_referrer?: string | null;
+}
+
+const STORAGE_KEY = "leazr_utm_attribution";
+const MAX_UTM_LENGTH = 200;
+const MAX_REFERRER_LENGTH = 500;
+
+const ATTRIBUTION_KEYS: (keyof AttributionData)[] = [
+  "utm_source",
+  "utm_medium",
+  "utm_campaign",
+  "utm_content",
+  "utm_term",
+  "fbclid",
+];
+
+function safeTrim(value: string | null | undefined, maxLength: number): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return trimmed.substring(0, maxLength);
+}
+
+/**
+ * Reads UTM / fbclid params from a URL query string. Returns null if the
+ * search string carries no attribution-relevant keys.
+ */
+export function parseAttributionFromSearch(search: string): AttributionData | null {
+  if (typeof search !== "string" || !search) return null;
+  const params = new URLSearchParams(search);
+  const result: AttributionData = {};
+  let found = false;
+  for (const key of ATTRIBUTION_KEYS) {
+    const limit = key === "fbclid" ? MAX_REFERRER_LENGTH : MAX_UTM_LENGTH;
+    const v = safeTrim(params.get(key), limit);
+    if (v) {
+      result[key] = v;
+      found = true;
+    }
+  }
+  return found ? result : null;
+}
+
+/**
+ * Capture-and-persist on landing. Idempotent — once we have a value we don't
+ * overwrite it on subsequent navigation, otherwise an internal click would
+ * lose the original attribution. (We do overwrite if a NEW campaign click
+ * arrives, i.e. fresh utm_source.)
+ */
+export function captureAttribution(): AttributionData | null {
+  if (typeof window === "undefined") return null;
+
+  const fromUrl = parseAttributionFromSearch(window.location.search);
+  const stored = readStoredAttribution();
+
+  if (fromUrl) {
+    // New click overrides — last-touch attribution.
+    const referrer = safeTrim(document.referrer, MAX_REFERRER_LENGTH);
+    const enriched: AttributionData = {
+      ...fromUrl,
+      landing_referrer: referrer && !referrer.includes(window.location.host)
+        ? referrer
+        : stored?.landing_referrer || null,
+    };
+    persistAttribution(enriched);
+    return enriched;
+  }
+
+  return stored;
+}
+
+export function readStoredAttribution(): AttributionData | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    return parsed as AttributionData;
+  } catch {
+    return null;
+  }
+}
+
+function persistAttribution(data: AttributionData) {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    /* sessionStorage unavailable — silently degrade */
+  }
+}
+
+export function clearStoredAttribution() {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* noop */
+  }
+}

--- a/supabase/functions/_shared/validationSchemas.ts
+++ b/supabase/functions/_shared/validationSchemas.ts
@@ -179,7 +179,18 @@ export const createProductRequestSchema = z.object({
     price_htva: z.number().nonnegative().max(100000, 'Prix invalide'),
     billing_period: z.enum(['monthly', 'yearly', 'one_time'], { errorMap: () => ({ message: 'Période de facturation invalide' }) }),
     quantity: z.number().int().positive().max(100, 'Quantité trop élevée').optional().default(1)
-  })).max(20, 'Maximum 20 services externes').optional()
+  })).max(20, 'Maximum 20 services externes').optional(),
+
+  // Attribution data (UTM / fbclid) — captured on landing for AdiOS / Meta Ads
+  attribution: z.object({
+    utm_source: z.string().trim().max(200).optional().nullable(),
+    utm_medium: z.string().trim().max(200).optional().nullable(),
+    utm_campaign: z.string().trim().max(200).optional().nullable(),
+    utm_content: z.string().trim().max(200).optional().nullable(),
+    utm_term: z.string().trim().max(200).optional().nullable(),
+    fbclid: z.string().trim().max(500).optional().nullable(),
+    landing_referrer: z.string().trim().max(500).optional().nullable()
+  }).optional()
 }).refine((data) => {
   // Au moins l'un des deux formats doit être fourni
   const hasOldFormat = !!data.client;

--- a/supabase/functions/adios-proxy/index.ts
+++ b/supabase/functions/adios-proxy/index.ts
@@ -1,0 +1,818 @@
+// AdiOS proxy — sends Meta Ads conversion events from Leazr to AdiOS.
+//
+// Four actions:
+//   - "test"           : webhook_url provided directly, sends a test payload.
+//                        Requires an authenticated user (called from settings).
+//   - "trigger"        : called from authenticated app code (e.g. internal status
+//                        change). Reads adios_integrations row for company_id.
+//   - "sign_contract"  : called from the public contract signing page (anonymous).
+//                        Authenticates via the signature_token. The function
+//                        loads the contract / offer / client server-side and
+//                        builds the AdiOS payload itself — clients cannot spoof
+//                        amount, email, or company_id.
+//   - "backfill"       : one-shot historical sync. Finds all signed contracts
+//                        whose offer is Meta-attributed and not yet synced,
+//                        and pushes each as a "won" conversion. Idempotent
+//                        via offers.adios_synced_at — safe to re-run.
+//
+// AdiOS expected JSON shape:
+//   { external_id, email, status, value_eur, occurred_at, notes }
+// Endpoint: https://app.adios.pub/api/webhooks/conversions/<token>
+
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+interface AdiOSProxyRequest {
+  action: "test" | "trigger" | "sign_contract" | "backfill";
+  // For "test"
+  webhook_url?: string;
+  // For "trigger" (server-built payload by the caller)
+  company_id?: string;
+  event_type?: string;
+  payload?: Record<string, unknown>;
+  // For "sign_contract" (anonymous, public)
+  signature_token?: string;
+  // For "backfill"
+  dry_run?: boolean;
+  max_to_send?: number;       // Hard cap per call, default 100
+  delay_between_ms?: number;  // Throttle, default 250ms
+}
+
+const ADIOS_HOST_HINT = "adios.pub";
+const TEST_PAYLOAD_KEYS = ["external_id", "email", "status", "value_eur", "occurred_at", "notes"];
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const adminSupabase = createClient(supabaseUrl, serviceRoleKey);
+
+    const body: AdiOSProxyRequest = await req.json();
+    const { action } = body;
+
+    if (!action || !["test", "trigger", "sign_contract", "backfill"].includes(action)) {
+      return jsonResponse(
+        { success: false, error: "Action invalide (test | trigger | sign_contract | backfill)" },
+        400,
+      );
+    }
+
+    // ---------- sign_contract: anonymous, token-authenticated ----------
+    if (action === "sign_contract") {
+      const { signature_token } = body;
+      if (!signature_token) {
+        return jsonResponse({ success: false, error: "signature_token manquant" }, 400);
+      }
+      return await handleSignContract(adminSupabase, signature_token);
+    }
+
+    // ---------- test / trigger: require authenticated user ----------
+    const authHeader = req.headers.get("Authorization");
+    if (!authHeader?.startsWith("Bearer ")) {
+      return jsonResponse({ success: false, error: "Non autorisé" }, 401);
+    }
+
+    const userSupabase = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+    const token = authHeader.replace("Bearer ", "");
+    const { data: claims, error: claimsError } = await userSupabase.auth.getUser(token);
+    if (claimsError || !claims?.user) {
+      return jsonResponse({ success: false, error: "Token invalide" }, 401);
+    }
+    const userId = claims.user.id;
+
+    if (action === "test") {
+      return await handleTest(userSupabase, adminSupabase, userId, body);
+    }
+    if (action === "backfill") {
+      return await handleBackfill(userSupabase, adminSupabase, userId, body);
+    }
+    return await handleTrigger(userSupabase, adminSupabase, userId, body);
+  } catch (error) {
+    console.error("[AdiOS Proxy] Unexpected error:", error);
+    return jsonResponse({ success: false, error: "Erreur interne du serveur" }, 500);
+  }
+});
+
+// =====================================================================
+// sign_contract — anonymous, token-authenticated (public signing page)
+// =====================================================================
+async function handleSignContract(adminSupabase: any, signatureToken: string) {
+  // Load contract by token. We accept tokens that produced a signature in the
+  // last 30 minutes — that's our anti-replay window.
+  const { data: contract, error: contractError } = await adminSupabase
+    .from("contracts")
+    .select(`
+      id, offer_id, client_id, company_id, client_email, client_name,
+      monthly_payment, contract_duration, contract_signed_at,
+      contract_signer_name, signature_status, leaser_name
+    `)
+    .eq("contract_signature_token", signatureToken)
+    .maybeSingle();
+
+  if (contractError || !contract) {
+    console.warn("[AdiOS sign_contract] Contract not found for token");
+    return jsonResponse({ success: false, skipped: true, error: "Contrat introuvable" }, 200);
+  }
+
+  if (contract.signature_status !== "signed" || !contract.contract_signed_at) {
+    return jsonResponse(
+      { success: false, skipped: true, error: "Contrat non signé" },
+      200,
+    );
+  }
+
+  const signedAt = new Date(contract.contract_signed_at).getTime();
+  if (Number.isFinite(signedAt) && Date.now() - signedAt > 30 * 60 * 1000) {
+    // Token still valid but signing happened > 30 min ago — refuse (anti-replay).
+    return jsonResponse(
+      { success: false, skipped: true, error: "Fenêtre de déclenchement expirée" },
+      200,
+    );
+  }
+
+  // Load AdiOS config for the company
+  const { data: config } = await adminSupabase
+    .from("adios_integrations")
+    .select("webhook_url, enabled_events, is_active")
+    .eq("company_id", contract.company_id)
+    .maybeSingle();
+
+  if (!config || !config.is_active || !config.webhook_url) {
+    return jsonResponse(
+      { success: false, skipped: true, error: "AdiOS non configuré pour cette compagnie" },
+      200,
+    );
+  }
+  if (!Array.isArray(config.enabled_events) || !config.enabled_events.includes("contract_signed")) {
+    return jsonResponse(
+      { success: false, skipped: true, error: "Événement contract_signed désactivé" },
+      200,
+    );
+  }
+
+  // Load offer (for source / meta_platform / UTMs / remarks) and client (for notes)
+  const [offerRes, clientRes] = await Promise.all([
+    contract.offer_id
+      ? adminSupabase
+          .from("offers")
+          .select("id, source, meta_platform, remarks, utm_source, utm_medium, utm_campaign, fbclid, landing_referrer, adios_synced_at")
+          .eq("id", contract.offer_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+    contract.client_id
+      ? adminSupabase
+          .from("clients")
+          .select("id, email, notes")
+          .eq("id", contract.client_id)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
+
+  const offer = offerRes.data;
+  const client = clientRes.data;
+
+  // Idempotency: if this offer was already pushed to AdiOS (runtime trigger ran
+  // earlier, or backfill caught it first), don't double-send.
+  if (offer?.adios_synced_at) {
+    return jsonResponse(
+      { success: false, skipped: true, reason: "already_synced", error: "Conversion déjà envoyée à AdiOS" },
+      200,
+    );
+  }
+
+  // Detect Meta source. Skip the webhook entirely if not Meta — AdiOS only
+  // cares about Meta-attributed conversions.
+  const meta = detectMetaSource({
+    meta_platform: offer?.meta_platform,
+    utm_source: offer?.utm_source,
+    utm_medium: offer?.utm_medium,
+    fbclid: offer?.fbclid,
+    offer_source: offer?.source,
+    offer_remarks: offer?.remarks,
+    client_notes: client?.notes,
+  });
+
+  if (!meta.isMeta) {
+    return jsonResponse(
+      { success: false, skipped: true, reason: "not_meta", error: "Lead non attribué à Meta" },
+      200,
+    );
+  }
+
+  const monthly = Number(contract.monthly_payment) || 0;
+  const duration = Number(contract.contract_duration) || 0;
+  const valueEur = Math.round(monthly * duration * 100) / 100;
+
+  const notesParts = [
+    `Source: ${meta.platform}`, // Facebook | Instagram | Meta
+    meta.detectionMethod ? `Detection: ${meta.detectionMethod}` : null,
+    contract.contract_signer_name ? `Signé par: ${contract.contract_signer_name}` : null,
+    contract.leaser_name ? `Bailleur: ${contract.leaser_name}` : null,
+  ].filter(Boolean);
+
+  const adiosPayload = {
+    external_id: contract.offer_id || contract.id,
+    email: client?.email || contract.client_email || "",
+    status: "won",
+    value_eur: valueEur,
+    occurred_at: contract.contract_signed_at,
+    notes: notesParts.join(" | "),
+  };
+
+  return await sendToAdiOS({
+    adminSupabase,
+    targetUrl: config.webhook_url,
+    targetCompanyId: contract.company_id,
+    payload: adiosPayload,
+    logTag: `sign_contract platform=${meta.platform}`,
+    markOfferIdOnSuccess: offer?.id || null,
+  });
+}
+
+// =====================================================================
+// test — settings UI
+// =====================================================================
+async function handleTest(
+  userSupabase: any,
+  adminSupabase: any,
+  userId: string,
+  body: AdiOSProxyRequest,
+) {
+  const { webhook_url, payload } = body;
+  if (!webhook_url) {
+    return jsonResponse({ success: false, error: "URL du webhook manquante" }, 400);
+  }
+  const validation = validateAdiOSUrl(webhook_url);
+  if (!validation.ok) return jsonResponse({ success: false, error: validation.error }, 400);
+
+  const testPayload = isValidAdiOSPayload(payload) ? payload : {
+    external_id: `test-${Date.now()}`,
+    email: "test@leazr.co",
+    status: "won",
+    value_eur: 0,
+    occurred_at: new Date().toISOString(),
+    notes: "Test de connexion AdiOS depuis Leazr",
+  };
+
+  const { data: profile } = await userSupabase
+    .from("profiles")
+    .select("company_id")
+    .eq("id", userId)
+    .single();
+  const targetCompanyId = profile?.company_id || null;
+
+  return await sendToAdiOS({
+    adminSupabase,
+    targetUrl: webhook_url,
+    targetCompanyId,
+    payload: testPayload,
+    logTag: "test",
+    skipDbUpdate: true,
+  });
+}
+
+// =====================================================================
+// trigger — server-built payload from authenticated app code
+// =====================================================================
+async function handleTrigger(
+  userSupabase: any,
+  adminSupabase: any,
+  userId: string,
+  body: AdiOSProxyRequest,
+) {
+  const { company_id, event_type, payload } = body;
+  if (!company_id) return jsonResponse({ success: false, error: "company_id manquant" }, 400);
+  if (!isValidAdiOSPayload(payload)) {
+    return jsonResponse({ success: false, error: "Payload AdiOS invalide" }, 400);
+  }
+
+  const { data: profile } = await userSupabase
+    .from("profiles")
+    .select("company_id")
+    .eq("id", userId)
+    .single();
+  if (profile?.company_id && profile.company_id !== company_id) {
+    return jsonResponse({ success: false, error: "Compagnie incorrecte" }, 403);
+  }
+
+  const { data: config } = await adminSupabase
+    .from("adios_integrations")
+    .select("webhook_url, enabled_events, is_active")
+    .eq("company_id", company_id)
+    .maybeSingle();
+
+  if (!config || !config.is_active || !config.webhook_url) {
+    return jsonResponse(
+      { success: false, skipped: true, error: "AdiOS non configuré ou inactif" },
+      200,
+    );
+  }
+
+  const eventToCheck = event_type || "contract_signed";
+  const enabledEvents = (config.enabled_events as string[]) || [];
+  if (!enabledEvents.includes(eventToCheck)) {
+    return jsonResponse(
+      { success: false, skipped: true, error: `Événement '${eventToCheck}' non activé` },
+      200,
+    );
+  }
+
+  const validation = validateAdiOSUrl(config.webhook_url);
+  if (!validation.ok) return jsonResponse({ success: false, error: validation.error }, 400);
+
+  return await sendToAdiOS({
+    adminSupabase,
+    targetUrl: config.webhook_url,
+    targetCompanyId: company_id,
+    payload: payload!,
+    logTag: `trigger ${eventToCheck}`,
+  });
+}
+
+// =====================================================================
+// backfill — push historical Meta-attributed signed contracts to AdiOS
+// =====================================================================
+//
+// Ran from the settings UI ("Importer l'historique" button). Idempotent:
+// each successful send stamps offers.adios_synced_at, so re-running the
+// backfill only picks up rows that haven't been synced yet.
+//
+// Throttled with a configurable delay between sends to avoid overloading
+// AdiOS. Hard cap of 100 rows per call by default — the UI can re-call
+// to drain a longer queue.
+async function handleBackfill(
+  userSupabase: any,
+  adminSupabase: any,
+  userId: string,
+  body: AdiOSProxyRequest,
+) {
+  const dryRun = body.dry_run === true;
+  const maxToSend = Math.max(1, Math.min(body.max_to_send ?? 100, 500));
+  const delayMs = Math.max(0, Math.min(body.delay_between_ms ?? 250, 5000));
+
+  // Resolve caller's company.
+  const { data: profile } = await userSupabase
+    .from("profiles")
+    .select("company_id, role")
+    .eq("id", userId)
+    .single();
+
+  const companyId = profile?.company_id;
+  if (!companyId) {
+    return jsonResponse({ success: false, error: "Compagnie introuvable" }, 403);
+  }
+
+  // Load AdiOS config for this company.
+  const { data: config } = await adminSupabase
+    .from("adios_integrations")
+    .select("webhook_url, enabled_events, is_active")
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  if (!config || !config.is_active || !config.webhook_url) {
+    return jsonResponse(
+      { success: false, error: "AdiOS non configuré ou inactif pour cette compagnie" },
+      400,
+    );
+  }
+  const validation = validateAdiOSUrl(config.webhook_url);
+  if (!validation.ok) return jsonResponse({ success: false, error: validation.error }, 400);
+
+  // Find candidates: signed contracts whose offer is Meta-attributed and not
+  // yet synced. We pre-filter on the offer (source='meta' OR meta_platform set
+  // OR utm_source present) to keep the result set small; final detection
+  // (including notes/remarks regex) happens row-by-row inside the loop.
+  const { data: candidates, error: candidatesError } = await adminSupabase
+    .from("contracts")
+    .select(`
+      id, offer_id, client_id, company_id, client_email, client_name,
+      monthly_payment, contract_duration, contract_signed_at,
+      contract_signer_name, leaser_name, signature_status,
+      offers!inner (
+        id, source, meta_platform, remarks,
+        utm_source, utm_medium, utm_campaign, fbclid, landing_referrer,
+        adios_synced_at
+      )
+    `)
+    .eq("company_id", companyId)
+    .eq("signature_status", "signed")
+    .not("contract_signed_at", "is", null)
+    .is("offers.adios_synced_at", null)
+    .order("contract_signed_at", { ascending: true })
+    .limit(maxToSend * 3); // generous because we'll filter further in JS
+
+  if (candidatesError) {
+    console.error("[AdiOS Backfill] Error fetching candidates:", candidatesError);
+    return jsonResponse(
+      { success: false, error: `Erreur de récupération: ${candidatesError.message}` },
+      500,
+    );
+  }
+
+  console.log(`[AdiOS Backfill] Found ${candidates?.length || 0} unsynced signed contracts (pre-filter)`);
+
+  // Pre-load all client emails + notes in one query (avoid N+1 inside the loop)
+  const clientIds = Array.from(new Set((candidates || [])
+    .map((c: any) => c.client_id)
+    .filter(Boolean))) as string[];
+  const clientByIdMap = new Map<string, { email: string | null; notes: string | null }>();
+  if (clientIds.length > 0) {
+    const { data: clients } = await adminSupabase
+      .from("clients")
+      .select("id, email, notes")
+      .in("id", clientIds);
+    for (const c of (clients || [])) {
+      clientByIdMap.set(c.id, { email: c.email, notes: c.notes });
+    }
+  }
+
+  const stats = {
+    total_candidates: candidates?.length || 0,
+    sent: 0,
+    skipped_not_meta: 0,
+    skipped_already_synced: 0,
+    errors: 0,
+    error_details: [] as Array<{ contract_id: string; error: string }>,
+    details: [] as Array<{ contract_id: string; offer_id: string; platform: string; value_eur: number }>,
+  };
+
+  for (const row of (candidates || [])) {
+    if (stats.sent >= maxToSend) break;
+
+    const offer = (row as any).offers;
+    if (!offer) continue;
+    if (offer.adios_synced_at) {
+      stats.skipped_already_synced++;
+      continue;
+    }
+
+    const clientInfo = row.client_id ? clientByIdMap.get(row.client_id) : null;
+
+    const meta = detectMetaSource({
+      meta_platform: offer.meta_platform,
+      utm_source: offer.utm_source,
+      utm_medium: offer.utm_medium,
+      fbclid: offer.fbclid,
+      offer_source: offer.source,
+      offer_remarks: offer.remarks,
+      client_notes: clientInfo?.notes ?? null,
+    });
+    if (!meta.isMeta) {
+      stats.skipped_not_meta++;
+      continue;
+    }
+
+    const monthly = Number(row.monthly_payment) || 0;
+    const duration = Number(row.contract_duration) || 0;
+    const valueEur = Math.round(monthly * duration * 100) / 100;
+
+    const notesParts = [
+      `Source: ${meta.platform}`,
+      `Detection: ${meta.detectionMethod}`,
+      "Backfill historique",
+      row.contract_signer_name ? `Signé par: ${row.contract_signer_name}` : null,
+    ].filter(Boolean);
+
+    const adiosPayload = {
+      external_id: row.offer_id || row.id,
+      email: clientInfo?.email || row.client_email || "",
+      status: "won",
+      value_eur: valueEur,
+      occurred_at: row.contract_signed_at,
+      notes: notesParts.join(" | "),
+    };
+
+    if (dryRun) {
+      stats.sent++; // count what WOULD be sent
+      stats.details.push({
+        contract_id: row.id,
+        offer_id: row.offer_id,
+        platform: meta.platform || "Meta",
+        value_eur: valueEur,
+      });
+      continue;
+    }
+
+    // Send. We deliberately DON'T use sendToAdiOS here because we want tighter
+    // control over the loop (each row is independent — one failure doesn't
+    // abort the batch). We do still update last_triggered_at on the config.
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 15000);
+      const adiosResponse = await fetch(config.webhook_url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(adiosPayload),
+        signal: controller.signal,
+      });
+      clearTimeout(timeoutId);
+
+      if (adiosResponse.status >= 200 && adiosResponse.status < 300) {
+        await adminSupabase
+          .from("offers")
+          .update({ adios_synced_at: new Date().toISOString() })
+          .eq("id", row.offer_id);
+        stats.sent++;
+        stats.details.push({
+          contract_id: row.id,
+          offer_id: row.offer_id,
+          platform: meta.platform || "Meta",
+          value_eur: valueEur,
+        });
+      } else {
+        const errText = await adiosResponse.text().catch(() => "");
+        stats.errors++;
+        stats.error_details.push({
+          contract_id: row.id,
+          error: `HTTP ${adiosResponse.status}: ${errText.substring(0, 200)}`,
+        });
+      }
+    } catch (err) {
+      stats.errors++;
+      stats.error_details.push({
+        contract_id: row.id,
+        error: err instanceof Error ? err.message : "Erreur réseau",
+      });
+    }
+
+    // Throttle so we don't hammer AdiOS
+    if (delayMs > 0 && stats.sent < maxToSend) {
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+
+  // Stamp the integration row so the UI shows "last activity"
+  if (!dryRun && stats.sent > 0) {
+    await adminSupabase
+      .from("adios_integrations")
+      .update({
+        last_triggered_at: new Date().toISOString(),
+        last_status: stats.errors === 0 ? "success" : "error",
+        last_error: stats.errors === 0
+          ? null
+          : `Backfill: ${stats.errors} erreurs sur ${stats.sent + stats.errors} envois`,
+      })
+      .eq("company_id", companyId);
+  }
+
+  console.log(`[AdiOS Backfill] Done — sent=${stats.sent}, skipped_not_meta=${stats.skipped_not_meta}, errors=${stats.errors}, dry_run=${dryRun}`);
+
+  return jsonResponse({
+    success: true,
+    dry_run: dryRun,
+    ...stats,
+  }, 200);
+}
+
+// =====================================================================
+// shared HTTP send + DB update
+// =====================================================================
+interface SendArgs {
+  adminSupabase: any;
+  targetUrl: string;
+  targetCompanyId: string | null;
+  payload: Record<string, unknown>;
+  logTag: string;
+  skipDbUpdate?: boolean;
+  // If set, the offer's adios_synced_at gets stamped on success so future
+  // calls (runtime or backfill) skip it.
+  markOfferIdOnSuccess?: string | null;
+}
+
+async function sendToAdiOS({
+  adminSupabase, targetUrl, targetCompanyId, payload, logTag, skipDbUpdate, markOfferIdOnSuccess,
+}: SendArgs) {
+  console.log(`[AdiOS Proxy] ${logTag} → ${redactUrl(targetUrl)} (company=${targetCompanyId ?? "unknown"})`);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+
+  let adiosResponse: Response;
+  try {
+    adiosResponse = await fetch(targetUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+  } catch (fetchError) {
+    clearTimeout(timeoutId);
+    const errorMessage = fetchError instanceof Error
+      ? (fetchError.name === "AbortError"
+          ? "Timeout: AdiOS n'a pas répondu dans les 15 secondes"
+          : `Erreur réseau: ${fetchError.message}`)
+      : "Impossible de contacter AdiOS";
+    console.error("[AdiOS Proxy] Fetch error:", errorMessage);
+
+    if (!skipDbUpdate && targetCompanyId) {
+      await adminSupabase
+        .from("adios_integrations")
+        .update({
+          last_triggered_at: new Date().toISOString(),
+          last_status: "error",
+          last_error: errorMessage.substring(0, 500),
+        })
+        .eq("company_id", targetCompanyId);
+    }
+    return jsonResponse({ success: false, error: errorMessage }, 502);
+  }
+
+  const status = adiosResponse.status;
+  let responseText = "";
+  try { responseText = await adiosResponse.text(); } catch { /* noop */ }
+  const ok = status >= 200 && status < 300;
+
+  console.log(`[AdiOS Proxy] AdiOS responded ${status} (${ok ? "ok" : "error"})`);
+
+  if (!skipDbUpdate && targetCompanyId) {
+    await adminSupabase
+      .from("adios_integrations")
+      .update({
+        last_triggered_at: new Date().toISOString(),
+        last_status: ok ? "success" : "error",
+        last_error: ok ? null : `HTTP ${status}: ${responseText.substring(0, 300)}`,
+      })
+      .eq("company_id", targetCompanyId);
+  }
+
+  // Stamp the offer as synced so we don't re-send on future runs.
+  if (ok && markOfferIdOnSuccess) {
+    await adminSupabase
+      .from("offers")
+      .update({ adios_synced_at: new Date().toISOString() })
+      .eq("id", markOfferIdOnSuccess);
+  }
+
+  if (ok) {
+    return jsonResponse({
+      success: true,
+      status,
+      message: "AdiOS a bien reçu la conversion",
+      response: responseText.substring(0, 200),
+    }, 200);
+  }
+  return jsonResponse({
+    success: false,
+    status,
+    error: `AdiOS a répondu avec le code ${status}`,
+    details: responseText.substring(0, 200),
+  }, 200);
+}
+
+// =====================================================================
+// Meta source detection — multi-tier, structured fields first
+// =====================================================================
+//
+// Priority order (highest signal first):
+//   1. offers.meta_platform — set by import-meta-leads from lead.platform.
+//      Most reliable: deterministic, machine-set, never lies.
+//   2. fbclid — Meta auto-appends this to outbound ad clicks. Strong signal.
+//   3. UTM params — utm_source / utm_medium captured on landing.
+//   4. offers.source = 'meta' — generic Meta attribution without platform info.
+//      Used for legacy meta-imported offers where meta_platform is NULL.
+//   5. Free-text scan of remarks + notes, anchored on the "Plateforme: X" line
+//      written by import-meta-leads. Anchored to avoid false positives from
+//      the generic "Facebook/Instagram" header line.
+//
+interface DetectInput {
+  meta_platform?: string | null;
+  utm_source?: string | null;
+  utm_medium?: string | null;
+  fbclid?: string | null;
+  offer_source?: string | null;
+  offer_remarks?: string | null;
+  client_notes?: string | null;
+}
+interface DetectResult {
+  isMeta: boolean;
+  platform: "Facebook" | "Instagram" | "Meta" | null;
+  detectionMethod: "meta_platform" | "fbclid" | "utm" | "source_meta" | "free_text" | null;
+}
+
+function detectMetaSource(input: DetectInput): DetectResult {
+  // 1) Structured column from import-meta-leads
+  const metaPlatform = (input.meta_platform || "").toLowerCase().trim();
+  if (metaPlatform === "facebook") {
+    return { isMeta: true, platform: "Facebook", detectionMethod: "meta_platform" };
+  }
+  if (metaPlatform === "instagram") {
+    return { isMeta: true, platform: "Instagram", detectionMethod: "meta_platform" };
+  }
+
+  const utmSource = (input.utm_source || "").toLowerCase().trim();
+  const utmMedium = (input.utm_medium || "").toLowerCase().trim();
+  const offerSource = (input.offer_source || "").toLowerCase().trim();
+  const fbclid = (input.fbclid || "").trim();
+
+  // 2) fbclid — Meta-attributed traffic
+  if (fbclid) {
+    if (utmSource.includes("instagram") || utmSource === "ig") {
+      return { isMeta: true, platform: "Instagram", detectionMethod: "fbclid" };
+    }
+    if (utmSource.includes("facebook") || utmSource === "fb") {
+      return { isMeta: true, platform: "Facebook", detectionMethod: "fbclid" };
+    }
+    return { isMeta: true, platform: "Meta", detectionMethod: "fbclid" };
+  }
+
+  // 3) UTM-based detection
+  for (const c of [utmSource, utmMedium]) {
+    if (!c) continue;
+    if (c.includes("instagram") || c === "ig") {
+      return { isMeta: true, platform: "Instagram", detectionMethod: "utm" };
+    }
+    if (c.includes("facebook") || c === "fb") {
+      return { isMeta: true, platform: "Facebook", detectionMethod: "utm" };
+    }
+    if (c.includes("meta")) {
+      return { isMeta: true, platform: "Meta", detectionMethod: "utm" };
+    }
+  }
+
+  // 4) source = 'meta' — generic Meta attribution (legacy meta-imported leads)
+  if (offerSource === "meta") {
+    // Try to recover platform from remarks/notes; otherwise fall through to
+    // the free-text scanner below which anchors on "Plateforme:".
+    const platformFromText = scanPlateformeLine([input.offer_remarks, input.client_notes]);
+    if (platformFromText) {
+      return { isMeta: true, platform: platformFromText, detectionMethod: "source_meta" };
+    }
+    return { isMeta: true, platform: "Meta", detectionMethod: "source_meta" };
+  }
+
+  // 5) Free-text fallback — only fires on /Plateforme:/ to avoid matching the
+  //    generic "META (Facebook/Instagram)" header that lists both platforms.
+  const platformFromText = scanPlateformeLine([input.offer_remarks, input.client_notes]);
+  if (platformFromText) {
+    return { isMeta: true, platform: platformFromText, detectionMethod: "free_text" };
+  }
+
+  return { isMeta: false, platform: null, detectionMethod: null };
+}
+
+/**
+ * Scans free-text fields for a "Plateforme: Facebook" / "Plateforme: Instagram"
+ * line, written by import-meta-leads in clients.notes and offers.remarks.
+ * Anchored on "plateforme:" so the generic "(Facebook/Instagram)" header
+ * doesn't trigger false positives.
+ */
+function scanPlateformeLine(fields: (string | null | undefined)[]): "Facebook" | "Instagram" | null {
+  const text = fields.filter(Boolean).join("\n");
+  if (!text) return null;
+  const match = text.match(/plateforme\s*:\s*(facebook|instagram)/i);
+  if (!match) return null;
+  const platform = match[1].toLowerCase();
+  if (platform === "facebook") return "Facebook";
+  if (platform === "instagram") return "Instagram";
+  return null;
+}
+
+// =====================================================================
+// utils
+// =====================================================================
+function jsonResponse(body: unknown, status: number) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+function validateAdiOSUrl(url: string): { ok: true } | { ok: false; error: string } {
+  let parsed: URL;
+  try { parsed = new URL(url); } catch { return { ok: false, error: "URL invalide" }; }
+  if (parsed.protocol !== "https:") return { ok: false, error: "L'URL doit être HTTPS" };
+  if (!parsed.hostname.includes(ADIOS_HOST_HINT)) {
+    console.warn("[AdiOS Proxy] URL doesn't look like an AdiOS webhook:", url);
+  }
+  return { ok: true };
+}
+
+function isValidAdiOSPayload(p: unknown): p is Record<string, unknown> {
+  if (!p || typeof p !== "object") return false;
+  // We only require external_id + status; everything else is best-effort.
+  const obj = p as Record<string, unknown>;
+  return typeof obj.external_id === "string" && typeof obj.status === "string";
+}
+
+function redactUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop() || "";
+    return `${u.host}${u.pathname.replace(last, last.substring(0, 8) + "…")}`;
+  } catch {
+    return "[invalid url]";
+  }
+}

--- a/supabase/functions/create-product-request/index.ts
+++ b/supabase/functions/create-product-request/index.ts
@@ -560,6 +560,11 @@ serve(async (req) => {
     
     console.log(`Type: ${offerType}, Source: ${offerSource}, Partner: ${data.partner_slug || 'none'}`);
 
+    // Attribution data (UTM / fbclid / referrer) — used by AdiOS for Meta Ads tracking.
+    const attribution = (data as any).attribution || {};
+    const trim200 = (v: unknown) => (typeof v === 'string' && v.trim() ? v.trim().substring(0, 200) : null);
+    const trim500 = (v: unknown) => (typeof v === 'string' && v.trim() ? v.trim().substring(0, 500) : null);
+
     const offerData = {
       id: requestId,
       client_id: clientId,
@@ -576,7 +581,7 @@ serve(async (req) => {
       source: offerSource,
       workflow_status: 'draft',
       status: 'pending',
-      remarks: data.partner_slug 
+      remarks: data.partner_slug
         ? `Demande via partenaire ${data.partner_name || data.partner_slug} (Grenke 36 mois)`
         : 'Demande créée via API web avec Grenke (36 mois)',
       user_id: null,
@@ -585,9 +590,17 @@ serve(async (req) => {
       dossier_number: dossierNumber,
       partner_slug: data.partner_slug || null,
       partner_name: data.partner_name || null,
-      workflow_template_id: offerType === 'web_request' ? 'f6e29d41-ef40-4253-ab08-e23060da47da' 
+      workflow_template_id: offerType === 'web_request' ? 'f6e29d41-ef40-4253-ab08-e23060da47da'
         : offerType === 'custom_pack_request' ? 'bf15a91e-39bb-4207-8a90-0c7e8624c052'
-        : null
+        : null,
+      // Attribution columns (added by adios_integration migration)
+      utm_source: trim200(attribution.utm_source),
+      utm_medium: trim200(attribution.utm_medium),
+      utm_campaign: trim200(attribution.utm_campaign),
+      utm_content: trim200(attribution.utm_content),
+      utm_term: trim200(attribution.utm_term),
+      fbclid: trim500(attribution.fbclid),
+      landing_referrer: trim500(attribution.landing_referrer)
     };
 
     const { error: offerError } = await supabaseAdmin.from('offers').insert(offerData);

--- a/supabase/functions/import-meta-leads/index.ts
+++ b/supabase/functions/import-meta-leads/index.ts
@@ -1262,6 +1262,11 @@ ${packRemarks}
           equipment_description: parsedPack.equipmentDescription,
           type: 'client_request',
           source: 'meta',
+          // Deterministic platform tag, used by the AdiOS conversion webhook to
+          // attribute the conversion to the correct ad platform (Facebook vs
+          // Instagram). The free-text "Plateforme: …" line stays in remarks for
+          // human readability; this column is the machine source of truth.
+          meta_platform: lead.platform === 'fb' ? 'facebook' : 'instagram',
           workflow_status: 'draft',
           status: 'pending',
           remarks: offerRemarks,

--- a/supabase/migrations/20260506100000_adios_integration.sql
+++ b/supabase/migrations/20260506100000_adios_integration.sql
@@ -1,0 +1,114 @@
+-- =====================================================
+-- AdiOS integration: Meta Ads conversion attribution
+-- =====================================================
+--
+-- 1) Add UTM / fbclid attribution columns on offers so we can identify
+--    which leads came from Meta (Facebook / Instagram) ad campaigns.
+--    Columns are nullable — zero impact on existing rows.
+-- 2) Create adios_integrations table (per-company webhook config),
+--    modeled on zapier_integrations.
+
+-- ---------- 1) Attribution columns on offers ----------
+
+ALTER TABLE public.offers
+  ADD COLUMN IF NOT EXISTS utm_source TEXT,
+  ADD COLUMN IF NOT EXISTS utm_medium TEXT,
+  ADD COLUMN IF NOT EXISTS utm_campaign TEXT,
+  ADD COLUMN IF NOT EXISTS utm_content TEXT,
+  ADD COLUMN IF NOT EXISTS utm_term TEXT,
+  ADD COLUMN IF NOT EXISTS fbclid TEXT,
+  ADD COLUMN IF NOT EXISTS landing_referrer TEXT,
+  -- Populated by the import-meta-leads edge function. Values: 'facebook' or 'instagram'.
+  -- Existing rows stay NULL and will fall back to source='meta' + free-text detection.
+  ADD COLUMN IF NOT EXISTS meta_platform TEXT
+    CHECK (meta_platform IS NULL OR meta_platform IN ('facebook', 'instagram')),
+  -- Stamp set by the adios-proxy edge function once the conversion has been
+  -- successfully delivered to AdiOS. Prevents double-counting on re-runs of
+  -- the runtime trigger or the backfill job.
+  ADD COLUMN IF NOT EXISTS adios_synced_at TIMESTAMP WITH TIME ZONE;
+
+-- Index helps lookups when reporting Meta-attributed offers.
+CREATE INDEX IF NOT EXISTS idx_offers_utm_source ON public.offers (utm_source)
+  WHERE utm_source IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_offers_meta_platform ON public.offers (meta_platform)
+  WHERE meta_platform IS NOT NULL;
+-- Used by the backfill to find offers still waiting to be synced.
+CREATE INDEX IF NOT EXISTS idx_offers_adios_pending ON public.offers (company_id)
+  WHERE adios_synced_at IS NULL AND source = 'meta';
+
+-- Backfill existing Meta leads: parse the platform out of the remarks header
+-- written by import-meta-leads. Best-effort; rows that don't match stay NULL.
+UPDATE public.offers
+   SET meta_platform = 'facebook'
+ WHERE source = 'meta'
+   AND meta_platform IS NULL
+   AND remarks ILIKE '%Plateforme: Facebook%';
+
+UPDATE public.offers
+   SET meta_platform = 'instagram'
+ WHERE source = 'meta'
+   AND meta_platform IS NULL
+   AND remarks ILIKE '%Plateforme: Instagram%';
+
+-- ---------- 2) adios_integrations table ----------
+
+CREATE TABLE IF NOT EXISTS public.adios_integrations (
+  id UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  company_id UUID NOT NULL REFERENCES public.companies(id) ON DELETE CASCADE,
+  webhook_url TEXT NOT NULL,
+  is_active BOOLEAN NOT NULL DEFAULT true,
+  -- Optional: include "lost" / "qualified" later. We start with "won" only.
+  enabled_events JSONB NOT NULL DEFAULT '["contract_signed"]'::jsonb,
+  last_triggered_at TIMESTAMP WITH TIME ZONE,
+  last_status TEXT,        -- 'success' | 'error' | NULL
+  last_error TEXT,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+  UNIQUE(company_id)
+);
+
+ALTER TABLE public.adios_integrations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can view their company's AdiOS config"
+  ON public.adios_integrations FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.company_id = adios_integrations.company_id
+    )
+  );
+
+CREATE POLICY "Users can insert their company's AdiOS config"
+  ON public.adios_integrations FOR INSERT
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.company_id = adios_integrations.company_id
+    )
+  );
+
+CREATE POLICY "Users can update their company's AdiOS config"
+  ON public.adios_integrations FOR UPDATE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.company_id = adios_integrations.company_id
+    )
+  );
+
+CREATE POLICY "Users can delete their company's AdiOS config"
+  ON public.adios_integrations FOR DELETE
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.profiles
+      WHERE profiles.id = auth.uid()
+        AND profiles.company_id = adios_integrations.company_id
+    )
+  );
+
+CREATE TRIGGER update_adios_integrations_updated_at
+  BEFORE UPDATE ON public.adios_integrations
+  FOR EACH ROW EXECUTE FUNCTION public.update_updated_at_column();


### PR DESCRIPTION
## Module AdiOS — suivi des conversions Meta Ads

Envoie automatiquement les conversions à AdiOS (https://app.adios.pub) quand un contrat issu de Meta (Facebook/Instagram) est signé. Inclut un **backfill historique** pour récupérer le ROAS sur les contrats déjà signés.

### Schéma DB

**`offers` — nouvelles colonnes**
- `meta_platform` (`'facebook'`/`'instagram'`) populée par `import-meta-leads` à partir de `lead.platform`
- `utm_source / utm_medium / utm_campaign / utm_content / utm_term / fbclid / landing_referrer` — capturés sur les pages publiques pour le trafic organique Meta
- `adios_synced_at` — watermark d'idempotence (jamais 2 envois pour la même offre)

**`adios_integrations`** — config webhook par compagnie (URL, actif, dernier statut), RLS scopée à `profiles.company_id`.

### Edge function `adios-proxy` (4 actions)

- `test` — ping depuis l'UI Paramètres
- `trigger` — payload construit côté serveur depuis du code authentifié
- `sign_contract` — anonyme, authentifié via `signature_token` (la page de signature est publique). Le payload (montant, email) est construit côté serveur — le client ne peut pas spoofer.
- `backfill` — sync historique throttlée (250 ms entre envois, max 200 par appel), idempotente via `adios_synced_at`

### Détection de la source (5 niveaux)

1. `meta_platform` — déterministe (depuis `import-meta-leads`)
2. `fbclid` — Meta l'auto-ajoute aux clics
3. UTMs (`utm_source=facebook|instagram|meta`)
4. `source='meta'` — fallback générique
5. Regex ancrée sur `Plateforme:\s*(facebook|instagram)` dans `remarks`/`notes`

Corrige un bug : l'ancienne regex matchait l'en-tête générique "META (Facebook/Instagram)" et classait certains FB en IG.

### Capture UTM front

`useUtmCapture()` au niveau `AppRoutes` + `sessionStorage`. Traverse le funnel multi-étapes et est forwardé par `create-product-request`.

### UI Paramètres

Nouvelle catégorie "Marketing" → carte AdiOS :
- URL webhook, toggle actif, bouton Tester
- **Importer l'historique** : aperçu dry-run + lancement avec compteurs (envoyés / non-Meta / déjà sync / erreurs)

### Migration backfill

La migration UPDATE les offres existantes `source='meta'` pour set `meta_platform` en parsant la ligne `Plateforme: …` que `import-meta-leads` écrit déjà dans `remarks`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)