### PR TITLE
Sécurité : durcir l'isolation multi-tenant des edge functions

### DIFF
--- a/src/components/catalog/ProductEditor.tsx
+++ b/src/components/catalog/ProductEditor.tsx
@@ -189,7 +189,8 @@ const ProductEditor: React.FC<ProductEditorProps> = ({
         ...data,
         imageUrl: uploadedImages[0] || "",
         image_url: uploadedImages[0] || "",
-        company_id: "c1ce66bb-3ad2-474d-b477-583baa7ff1c0", // Get from context in real app
+        // company_id is derived server-side from the authenticated user's tenant
+        // (see createProduct in catalogService) — never hardcode it here.
       };
 
       if (isEditMode && productToEdit) {

--- a/src/services/catalogService.ts
+++ b/src/services/catalogService.ts
@@ -358,9 +358,19 @@ export const deleteCategory = async (categoryId: string) => {
 };
 
 export const createProduct = async (productData: any) => {
+  // Always derive the tenant from the authenticated user — never trust a
+  // company_id supplied by the caller. This prevents products from being
+  // mis-assigned (or maliciously assigned) to another tenant.
+  const companyId = await getCurrentUserCompanyId();
+  if (!companyId) {
+    throw new Error("Impossible de déterminer l'entreprise de l'utilisateur courant.");
+  }
+
+  const { company_id: _ignored, ...rest } = productData ?? {};
+
   const { data, error } = await supabase
     .from("products")
-    .insert(productData)
+    .insert({ ...rest, company_id: companyId })
     .select()
     .single();
 

--- a/supabase/functions/_shared/security.ts
+++ b/supabase/functions/_shared/security.ts
@@ -126,8 +126,14 @@ export async function requireElevatedAccess(
       };
     }
 
-    const payload = decodeJwtPayload(token);
-    if (allowServiceRole && payload?.role === 'service_role') {
+    // SECURITY: only accept the service-role shortcut when the bearer token is
+    // *exactly* the real service-role key. The previous check trusted the
+    // unverified JWT payload (`payload.role === 'service_role'`), which an
+    // attacker could forge with a self-crafted token on any function deployed
+    // with `verify_jwt = false` (e.g. notify-documents-uploaded,
+    // send-signed-contract-email, update-extended-contracts). An exact-string
+    // match against the secret key cannot be forged.
+    if (allowServiceRole && token === supabaseServiceRoleKey) {
       return {
         ok: true,
         context: {

--- a/supabase/functions/billit-integration/index.ts
+++ b/supabase/functions/billit-integration/index.ts
@@ -204,7 +204,7 @@ function createTestResponse(success: boolean, message: string, results: any) {
   });
 }
 
-async function handleSendExistingInvoice(invoiceId: string) {
+async function handleSendExistingInvoice(invoiceId: string, callerCompanyId: string) {
   console.log("📤 Envoi facture existante vers Billit:", invoiceId);
   
   try {
@@ -232,6 +232,12 @@ async function handleSendExistingInvoice(invoiceId: string) {
 
     if (invoiceError || !invoice) {
       throw new Error(`Facture non trouvée: ${invoiceError?.message || 'ID invalide'}`);
+    }
+
+    // SECURITY (multi-tenant): the invoice is fetched by id with the service
+    // role, so verify it belongs to the caller's company before sending it.
+    if (invoice.company_id !== callerCompanyId) {
+      throw new Error("Accès refusé : cette facture n'appartient pas à votre entreprise");
     }
 
     // Vérifier l'intégration Billit
@@ -441,17 +447,50 @@ serve(async (req) => {
     const requestData: any = await req.json();
     console.log("🔄 Début requête Billit:", JSON.stringify(requestData, null, 2));
 
+    // SECURITY (multi-tenant): authenticate the caller and derive their company
+    // from their profile. The handler previously trusted `companyId` from the
+    // request body, letting an authenticated user generate/send invoices through
+    // ANOTHER tenant's Billit account. Every operation is now forced to the
+    // caller's own company.
+    const authUrl = Deno.env.get("SUPABASE_URL")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+    const billitAuthHeader = req.headers.get("Authorization") || "";
+    const billitToken = billitAuthHeader.replace(/^Bearer\s+/i, "").trim();
+    if (!billitToken) {
+      return new Response(JSON.stringify({ success: false, error: "Non authentifié" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const billitAuthClient = createClient(authUrl, anonKey, {
+      global: { headers: { Authorization: `Bearer ${billitToken}` } },
+    });
+    const { data: { user: billitUser } } = await billitAuthClient.auth.getUser(billitToken);
+    if (!billitUser) {
+      return new Response(JSON.stringify({ success: false, error: "Non authentifié" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const { data: billitProfile } = await billitAuthClient
+      .from("profiles").select("company_id").eq("id", billitUser.id).maybeSingle();
+    const callerCompanyId: string | undefined = billitProfile?.company_id;
+    if (!callerCompanyId) {
+      return new Response(JSON.stringify({ success: false, error: "Accès refusé" }), {
+        status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     // Mode test de l'intégration
     if (requestData.testMode) {
-      return await handleBillitTest(requestData.companyId);
+      return await handleBillitTest(callerCompanyId);
     }
 
     // Action d'envoi d'une facture existante
     if (requestData.action === 'send' && requestData.invoiceId) {
-      return await handleSendExistingInvoice(requestData.invoiceId);
+      return await handleSendExistingInvoice(requestData.invoiceId, callerCompanyId);
     }
 
-    const { contractId, companyId } = requestData;
+    const { contractId } = requestData;
+    const companyId = callerCompanyId;
     console.log("📋 Génération facture Billit pour contrat:", contractId);
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL");
@@ -562,6 +601,7 @@ serve(async (req) => {
         )
       `)
       .eq('id', contractId)
+      .eq('company_id', companyId)
       .single();
 
     console.log("📄 Données contrat:", { contract, error: contractError });

--- a/supabase/functions/client-ai-chat/index.ts
+++ b/supabase/functions/client-ai-chat/index.ts
@@ -17,13 +17,66 @@ serve(async (req) => {
   }
 
   try {
-    const { messages, clientId, companyId } = await req.json();
+    const { messages, clientId: reqClientId } = await req.json();
     const LOVABLE_API_KEY = Deno.env.get("LOVABLE_API_KEY");
     if (!LOVABLE_API_KEY) throw new Error("LOVABLE_API_KEY is not configured");
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const supabaseKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
     const supabase = createClient(supabaseUrl, supabaseKey);
+
+    // SECURITY (multi-tenant): this endpoint streams a client's full financial
+    // history (contracts, offers, invoices) into the AI context. It is
+    // verify_jwt=false, so we MUST authenticate the caller ourselves and prove
+    // they own the requested client. Never trust clientId/companyId from the
+    // body — derive the company from the verified client row instead.
+    const authHeader = req.headers.get("Authorization") || "";
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    if (!token) {
+      return new Response(JSON.stringify({ error: "Non authentifié" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const authClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data: { user } } = await authClient.auth.getUser(token);
+    if (!user) {
+      return new Response(JSON.stringify({ error: "Non authentifié" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    if (!reqClientId) {
+      return new Response(JSON.stringify({ error: "clientId requis" }), {
+        status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { data: clientRow } = await supabase
+      .from("clients")
+      .select("id, company_id, user_id")
+      .eq("id", reqClientId)
+      .maybeSingle();
+
+    const { data: me } = await supabase
+      .from("profiles")
+      .select("company_id")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    const isOwner = clientRow?.user_id === user.id;
+    const isSameCompanyStaff = !!me?.company_id && clientRow?.company_id === me.company_id;
+    if (!clientRow || (!isOwner && !isSameCompanyStaff)) {
+      return new Response(JSON.stringify({ error: "Accès refusé" }), {
+        status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    // Authoritative, tamper-proof identifiers derived from the verified client.
+    const clientId = clientRow.id;
+    const companyId = clientRow.company_id;
 
     // Fetch knowledge base articles
     let knowledgeContext = "";

--- a/supabase/functions/generate-offer-summary/index.ts
+++ b/supabase/functions/generate-offer-summary/index.ts
@@ -49,8 +49,22 @@ serve(async (req) => {
 
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    // ── 1. Fetch offer details ─────────────────────────────────────────────
-    const { data: offer, error: offerError } = await supabase
+    // SECURITY (multi-tenant): validate the offer through a client scoped to the
+    // caller's JWT so RLS enforces tenant ownership. Without this, any
+    // authenticated user could pass another company's offer_id and receive an
+    // AI summary of that company's client/KYC/financials (data exfiltration).
+    const authHeader = req.headers.get("Authorization") || "";
+    if (!authHeader) {
+      return new Response(JSON.stringify({ error: "Non authentifié" }), {
+        status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const callerClient = createClient(supabaseUrl, Deno.env.get("SUPABASE_ANON_KEY")!, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    // ── 1. Fetch offer details (RLS-scoped to the caller's tenant) ──────────
+    const { data: offer, error: offerError } = await callerClient
       .from("offers")
       .select(
         "dossier_number, client_name, client_id, workflow_status, monthly_payment, amount, duration, internal_score, leaser_score, created_at, type, is_purchase, rejection_category, previous_offer_id"

--- a/supabase/functions/get-secret/index.ts
+++ b/supabase/functions/get-secret/index.ts
@@ -82,7 +82,7 @@ serve(async (req) => {
     }
 
     const { key } = await req.json();
-    
+
     if (!key) {
       return new Response(
         JSON.stringify({
@@ -91,15 +91,41 @@ serve(async (req) => {
         }),
         {
           status: 400,
-          headers: { 
+          headers: {
             "Content-Type": "application/json",
-            ...corsHeaders 
+            ...corsHeaders
           },
         }
       );
     }
 
-    // Récupérer la valeur du secret (de façon sécurisée)
+    // SECURITY: never allow this endpoint to dump arbitrary environment
+    // variables (it previously returned `Deno.env.get(key)` for ANY key, which
+    // would expose SUPABASE_SERVICE_ROLE_KEY, provider API keys, the JWT secret,
+    // etc. to a compromised SaaS-admin session). Only an explicit allow-list of
+    // non-critical / publishable values may ever be returned.
+    const ALLOWED_SECRET_KEYS = new Set<string>([
+      "STRIPE_PUBLISHABLE_KEY",
+    ]);
+
+    if (!ALLOWED_SECRET_KEYS.has(key)) {
+      console.warn(`[get-secret] Denied request for non-whitelisted key "${key}" by user ${user.id}`);
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: "Clé non autorisée",
+        }),
+        {
+          status: 403,
+          headers: {
+            "Content-Type": "application/json",
+            ...corsHeaders,
+          },
+        }
+      );
+    }
+
+    console.log(`[get-secret] Allowed key "${key}" served to SaaS admin ${user.id}`);
     const value = Deno.env.get(key);
     
     // Pour des raisons de sécurité, ne pas retourner le message d'erreur précis

--- a/supabase/functions/mollie-webhook/index.ts
+++ b/supabase/functions/mollie-webhook/index.ts
@@ -123,15 +123,23 @@ serve(async (req) => {
       if (mandateId) {
         console.log(`[Mollie Webhook] Mandate ${mandateId} created for contract ${contractId}`);
         
-        // Store mandate info on contract
-        await supabase
+        // Store mandate info on contract. Scope by company_id (when present in
+        // the Mollie-authenticated metadata) as a defense-in-depth guard so a
+        // contract can never be updated across tenant boundaries.
+        let contractUpdate = supabase
           .from("contracts")
-          .update({ 
+          .update({
             mollie_customer_id: payment.customerId,
             mollie_mandate_id: mandateId,
             mollie_mandate_status: "valid",
           })
           .eq("id", contractId);
+
+        if (companyId) {
+          contractUpdate = contractUpdate.eq("company_id", companyId);
+        }
+
+        await contractUpdate;
       }
     }
 

--- a/supabase/functions/notify-ticket-reply/index.ts
+++ b/supabase/functions/notify-ticket-reply/index.ts
@@ -27,8 +27,27 @@ Deno.serve(async (req) => {
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     );
 
-    // Get ticket with client info
-    const { data: ticket, error: ticketError } = await supabaseAdmin
+    // SECURITY (multi-tenant): this endpoint is verify_jwt=false and is called
+    // by an authenticated support agent. Read the ticket through a client scoped
+    // to the CALLER's JWT so RLS guarantees the agent can only notify on tickets
+    // belonging to their own tenant — otherwise any caller could email another
+    // company's client just by guessing a ticketId.
+    const authHeader = req.headers.get('Authorization') || '';
+    const token = authHeader.replace(/^Bearer\s+/i, '').trim();
+    if (!token) {
+      return new Response(
+        JSON.stringify({ error: 'Non authentifié' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
+    const callerClient = createClient(
+      Deno.env.get('SUPABASE_URL')!,
+      Deno.env.get('SUPABASE_ANON_KEY')!,
+      { global: { headers: { Authorization: `Bearer ${token}` } } }
+    );
+
+    // Get ticket with client info (RLS-scoped to the caller's tenant)
+    const { data: ticket, error: ticketError } = await callerClient
       .from('support_tickets')
       .select('subject, clients(name, email), companies(name)')
       .eq('id', ticketId)

--- a/supabase/functions/send-leaser-documents/index.ts
+++ b/supabase/functions/send-leaser-documents/index.ts
@@ -96,7 +96,11 @@ serve(async (req) => {
     const attachments: Array<{ filename: string; content: string }> = [];
 
     if (document_ids.length > 0) {
-      const { data: docs, error: docsErr } = await admin
+      // SECURITY (multi-tenant): read documents through the caller-scoped client
+      // so RLS guarantees they belong to the caller's tenant. The service-role
+      // `admin` client is used only for the storage download below (paths come
+      // from rows already validated here).
+      const { data: docs, error: docsErr } = await userClient
         .from("offer_documents")
         .select("id, file_name, file_path, document_type")
         .in("id", document_ids);
@@ -295,7 +299,9 @@ table.info td{padding:9px 14px;font-size:13px}
 
     // ── Persist sent_at in billing_data ──
     if (invoice_id) {
-      const { data: inv } = await admin
+      // SECURITY (multi-tenant): read+update the invoice through the
+      // caller-scoped client so RLS blocks cross-tenant writes.
+      const { data: inv } = await userClient
         .from("invoices")
         .select("billing_data")
         .eq("id", invoice_id)
@@ -303,7 +309,7 @@ table.info td{padding:9px 14px;font-size:13px}
 
       if (inv) {
         const existing = inv.billing_data ?? {};
-        await admin
+        await userClient
           .from("invoices")
           .update({
             billing_data: {

--- a/supabase/functions/send-manual-followup-email/index.ts
+++ b/supabase/functions/send-manual-followup-email/index.ts
@@ -63,12 +63,22 @@ const handler = async (req: Request): Promise<Response> => {
     // Use service role for DB operations
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    // Get contract company info for sender name
-    const { data: contract } = await supabase
+    // SECURITY (multi-tenant): read the contract through the caller-scoped
+    // client (supabaseAuth) so RLS enforces tenant ownership, and reject if the
+    // caller cannot see it — otherwise any authenticated user could trigger a
+    // follow-up email tied to another tenant's contract by guessing its id.
+    const { data: contract } = await supabaseAuth
       .from('contracts')
       .select('company_id, contract_number')
       .eq('id', contractId)
       .single();
+
+    if (!contract) {
+      return new Response(
+        JSON.stringify({ success: false, error: 'Contrat introuvable ou accès refusé' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      );
+    }
 
     let senderName = "iTakecare";
     if (contract?.company_id) {

--- a/supabase/functions/send-no-follow-up-email/index.ts
+++ b/supabase/functions/send-no-follow-up-email/index.ts
@@ -34,17 +34,27 @@ const handler = async (req: Request): Promise<Response> => {
     // Initialiser le client Supabase
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
     const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabaseAnonKey = Deno.env.get('SUPABASE_ANON_KEY')!;
     const supabase = createClient(supabaseUrl, supabaseServiceKey);
 
-    // Récupérer les données de l'offre
-    const { data: offer, error: offerError } = await supabase
+    // SECURITY (multi-tenant): fetch the offer through a client scoped to the
+    // CALLER's JWT so Row-Level Security applies. This guarantees the caller
+    // can only act on offers belonging to their own tenant — without it, the
+    // service-role client below would let any authenticated user trigger a
+    // "file closure" email on another company's offer/client.
+    const authHeader = req.headers.get('Authorization') || '';
+    const callerClient = createClient(supabaseUrl, supabaseAnonKey, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
+    const { data: offer, error: offerError } = await callerClient
       .from('offers')
       .select('*')
       .eq('id', offerId)
       .single();
 
     if (offerError || !offer) {
-      console.error('❌ Erreur lors de la récupération de l\'offre:', offerError);
+      console.error('❌ Offre introuvable ou accès refusé (tenant):', offerError);
       throw new Error('Offre introuvable');
     }
 

--- a/supabase/functions/send-offer-email/index.ts
+++ b/supabase/functions/send-offer-email/index.ts
@@ -74,6 +74,24 @@ serve(async (req) => {
       throw new Error('Missing required fields');
     }
 
+    // SECURITY (multi-tenant): ensure the authenticated caller actually owns
+    // this offer before sending mail on its behalf. We check visibility through
+    // an RLS-scoped client so a user from one tenant cannot send an offer email
+    // attributed to another tenant's offer.
+    const callerClient = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_ANON_KEY') ?? '',
+      { global: { headers: { Authorization: authHeader } } }
+    );
+    const { data: ownedOffer } = await callerClient
+      .from('offers')
+      .select('id')
+      .eq('id', offerId)
+      .maybeSingle();
+    if (!ownedOffer) {
+      throw new Error('Forbidden - offer not in your tenant');
+    }
+
     if (!RESEND_API_KEY) {
       throw new Error('RESEND_API_KEY is not configured');
     }

--- a/supabase/functions/send-push-notification/index.ts
+++ b/supabase/functions/send-push-notification/index.ts
@@ -262,12 +262,59 @@ serve(async (req) => {
       );
     }
 
+    // SECURITY (multi-tenant): this endpoint is verify_jwt=false and targets
+    // push subscriptions by user_id/company_id taken from the body. Internal
+    // callers (other edge functions) authenticate with the real service-role
+    // key and may target freely. Any OTHER caller is an end user: we verify
+    // their JWT and force the company scope to THEIR own company, so a user from
+    // tenant A can never push notifications into tenant B.
+    const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const authHeader = req.headers.get("Authorization") || "";
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    const isInternal = token === serviceRoleKey;
+
+    let scopedCompanyId: string | null = company_id ?? null;
+    if (!isInternal) {
+      const authClient = createClient(
+        Deno.env.get("SUPABASE_URL")!,
+        Deno.env.get("SUPABASE_ANON_KEY")!,
+        { global: { headers: { Authorization: `Bearer ${token}` } } }
+      );
+      const { data: { user } } = await authClient.auth.getUser(token);
+      if (!user) {
+        return new Response(
+          JSON.stringify({ error: "Non authentifié" }),
+          { status: 401, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
+      const { data: me } = await supabase
+        .from("profiles")
+        .select("company_id")
+        .eq("id", user.id)
+        .maybeSingle();
+      if (!me?.company_id) {
+        return new Response(
+          JSON.stringify({ error: "Accès refusé" }),
+          { status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" } }
+        );
+      }
+      scopedCompanyId = me.company_id;
+    }
+
     // Build subscription query
     let query = supabase.from("push_subscriptions").select("id, endpoint, subscription");
-    if (user_id) {
-      query = query.eq("user_id", user_id);
-    } else if (company_id) {
-      query = query.eq("company_id", company_id);
+    if (isInternal) {
+      if (user_id) {
+        query = query.eq("user_id", user_id);
+      } else if (company_id) {
+        query = query.eq("company_id", company_id);
+      }
+    } else {
+      // End users are always constrained to their own company.
+      query = query.eq("company_id", scopedCompanyId);
+      if (user_id) {
+        query = query.eq("user_id", user_id);
+      }
     }
 
     const { data: subs, error: fetchErr } = await query;

--- a/supabase/functions/send-reminder-email/index.ts
+++ b/supabase/functions/send-reminder-email/index.ts
@@ -61,13 +61,22 @@ serve(async (req) => {
 
     console.log("Request data:", { offerId, reminderType, reminderLevel, hasPdf: !!pdfBase64, signerId });
 
+    // SECURITY (multi-tenant): fetch the offer through a client scoped to the
+    // caller's JWT so RLS guarantees they can only send reminders for offers in
+    // their own tenant. The service-role client above bypasses RLS, which would
+    // otherwise let any authenticated user read another company's client email
+    // and trigger an email to that client just by passing its offerId.
+    const callerClient = createClient(supabaseUrl, Deno.env.get("SUPABASE_ANON_KEY") as string, {
+      global: { headers: { Authorization: authHeader } },
+    });
+
     // Get offer with client and company info
-    const { data: offer, error: offerError } = await supabase
+    const { data: offer, error: offerError } = await callerClient
       .from('offers')
       .select(`
-        id, 
-        client_name, 
-        client_email, 
+        id,
+        client_name,
+        client_email,
         client_id,
         amount,
         financed_amount,

--- a/supabase/migrations/20260607120000_grenke_submissions_rls.sql
+++ b/supabase/migrations/20260607120000_grenke_submissions_rls.sql
@@ -1,0 +1,16 @@
+-- Defense-in-depth: grenke_submissions previously had RLS DISABLED, relying
+-- solely on the edge function (service role) to enforce the company check.
+-- With RLS off, any role holding a table GRANT could read every tenant's rows.
+-- The service role bypasses RLS, so enabling it does NOT affect the existing
+-- edge-function read/write path; it only closes direct cross-tenant access.
+
+ALTER TABLE public.grenke_submissions ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated users may read only their own company's submission history.
+-- (Writes continue to happen exclusively through the service-role edge function.)
+DROP POLICY IF EXISTS grenke_submissions_company_read ON public.grenke_submissions;
+CREATE POLICY grenke_submissions_company_read
+  ON public.grenke_submissions
+  FOR SELECT
+  TO authenticated
+  USING (company_id = public.get_user_company_id());


### PR DESCRIPTION
Ferme les vecteurs d'accès cross-tenant repérés lors de l'audit multi-tenant.

## Corrigé
- **security.ts** : raccourci service_role basé sur un JWT non vérifié → comparaison exacte avec la clé service_role (fermait une forge admin sur les functions verify_jwt=false).
- **client-ai-chat** : endpoint public exfiltrant contrats/offres/factures de n'importe quel client → exige le JWT + vérifie l'ownership.
- **get-secret** : renvoyait n'importe quelle variable d'env → whitelist stricte.
- **billit-integration** : companyId du body → auth appelant + company forcée.
- generate-offer-summary, send-reminder-email, notify-ticket-reply, send-no-follow-up-email, send-leaser-documents : lecture tenant via client scopé RLS.
- send-push-notification : interne vs user forcé sur sa company.
- send-offer-email, send-manual-followup-email : contrôle d'ownership.
- mollie-webhook : garde-fou company_id sur UPDATE contrats.
- catalogService.createProduct / ProductEditor : company_id du tenant authentifié (UUID iTakecare retiré).

## ⚠️ Avant merge
- Appliquer la migration `20260607120000_grenke_submissions_rls.sql` (idempotente) — **PAS via `supabase db push`** (historique désynchronisé), mais via le SQL editor Supabase.
- Build Vite OK. Edge functions non testées localement (Deno).

🤖 Generated with [Claude Code](https://claude.com/claude-code)