### PR TITLE
Billing SaaS Mollie : abonnement, grille éditable, tarification par modules

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,7 @@ import LeazrSaasClients from "@/pages/LeazrSaasClients";
 import LeazrSaaSUsers from "@/pages/LeazrSaaSUsers";
 import CompanyDetailsPage from "@/pages/CompanyDetailsPage";
 import CompanySubscriptionPage from "@/pages/CompanySubscriptionPage";
+import SubscriptionSettings from "@/pages/SubscriptionSettings";
 import CompanyActionsPage from "@/pages/CompanyActionsPage";
 import LeazrSaaSAnalytics from "@/pages/LeazrSaaSAnalytics";
 import LeazrSaaSBilling from "@/pages/LeazrSaaSBilling";
@@ -316,6 +317,7 @@ const AppRoutes = () => {
       <Route path="panier" element={<Layout><CartPage /></Layout>} />
       
       {/* Settings sub-routes */}
+      <Route path="settings/subscription" element={<Layout><SubscriptionSettings /></Layout>} />
       <Route path="settings/company-values" element={<Layout><CompanyValuesSettings /></Layout>} />
       <Route path="settings/company-metrics" element={<Layout><CompanyMetricsSettings /></Layout>} />
       <Route path="settings/partner-logos" element={<Layout><PartnerLogosSettings /></Layout>} />

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -5,6 +5,7 @@ import { useIsMobile } from "@/hooks/use-mobile";
 import Sidebar from "./Sidebar";
 import LeazrSaaSSidebar from "./LeazrSaaSSidebar";
 import MobileLayout from "@/components/mobile/MobileLayout";
+import SubscriptionBanner from "@/components/subscription/SubscriptionBanner";
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -39,6 +40,8 @@ const Layout = ({ children }: LayoutProps) => {
       )}
       
       <main className="flex-1 overflow-y-auto">
+        {/* Bandeau de fin d'essai (blocage doux) — masqué pour l'admin SaaS plateforme */}
+        {!shouldUseLeazrSaaSSidebar && <SubscriptionBanner />}
         {children}
       </main>
     </div>

--- a/src/components/saas/ModuleEditDialog.tsx
+++ b/src/components/saas/ModuleEditDialog.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import { updateModule, type SaasModule } from "@/services/saasModulesService";
+
+interface Props {
+  module: SaasModule;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+/**
+ * Édition d'un module du catalogue Leazr (nom, description, prix add-on par
+ * tier, statut core). Réservé au super_admin via RLS.
+ */
+const ModuleEditDialog: React.FC<Props> = ({ module, onClose, onSaved }) => {
+  const [name, setName] = useState(module.name);
+  const [description, setDescription] = useState(module.description);
+  const [isCore, setIsCore] = useState(module.isCore);
+  const [priceStarter, setPriceStarter] = useState(String(module.priceStarter));
+  const [pricePro, setPricePro] = useState(String(module.pricePro));
+  const [priceBusiness, setPriceBusiness] = useState(String(module.priceBusiness));
+  const [saving, setSaving] = useState(false);
+
+  const num = (v: string) => Math.max(0, Number(v.replace(",", ".")) || 0);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      toast.error("Le nom est requis.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await updateModule(module.slug, {
+        name: name.trim(),
+        description: description.trim(),
+        isCore,
+        priceStarter: num(priceStarter),
+        pricePro: num(pricePro),
+        priceBusiness: num(priceBusiness),
+      });
+      if (res.success) {
+        toast.success(`Module ${name} mis à jour.`);
+        onSaved();
+      } else {
+        toast.error(res.error || "Échec de la mise à jour.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Module : {module.name}</DialogTitle>
+          <DialogDescription>
+            Les prix sont des add-ons mensuels (€) facturés quand le module est activé
+            au-delà du socle inclus dans le plan. Un module « core » est inclus partout.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <Label htmlFor="mod-name">Nom</Label>
+            <Input id="mod-name" value={name} onChange={(e) => setName(e.target.value)} />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="mod-desc">Description</Label>
+            <Input id="mod-desc" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+
+          <div className="grid grid-cols-3 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="mod-ps">Add-on Starter (€)</Label>
+              <Input id="mod-ps" inputMode="decimal" value={priceStarter} onChange={(e) => setPriceStarter(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="mod-pp">Add-on Pro (€)</Label>
+              <Input id="mod-pp" inputMode="decimal" value={pricePro} onChange={(e) => setPricePro(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="mod-pb">Add-on Business (€)</Label>
+              <Input id="mod-pb" inputMode="decimal" value={priceBusiness} onChange={(e) => setPriceBusiness(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Switch id="mod-core" checked={isCore} onCheckedChange={setIsCore} />
+            <Label htmlFor="mod-core">Module « core » (inclus dans tous les plans)</Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Annuler
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Enregistrer
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ModuleEditDialog;

--- a/src/components/saas/SaaSPlansManager.tsx
+++ b/src/components/saas/SaaSPlansManager.tsx
@@ -15,77 +15,17 @@ import {
   Zap
 } from "lucide-react";
 import { useModules, useSaaSData } from "@/hooks/useSaaSData";
+import { SAAS_PLANS_LIST, type SaasPlan } from "@/config/saasPlans";
 
-interface Plan {
-  id: string;
-  name: string;
-  price: number;
-  description: string;
-  features: string[];
-  maxUsers: number;
-  maxModules: number;
-  popular: boolean;
-}
+type Plan = SaasPlan;
 
 const SaaSPlansManager = () => {
   const [activeTab, setActiveTab] = useState<'plans' | 'modules'>('plans');
   const { modules, loading: modulesLoading } = useModules();
   const { companies } = useSaaSData();
 
-  // Plans basés sur les vraies données Supabase
-  const plans: Plan[] = [
-    {
-      id: 'starter',
-      name: 'Starter',
-      price: 49,
-      description: 'Parfait pour débuter avec Leazr',
-      features: [
-        'Modules principaux inclus',
-        '1 utilisateur',
-        'Support email',
-        '1 GB de stockage',
-        'Rapports de base'
-      ],
-      maxUsers: 1,
-      maxModules: 1,
-      popular: false
-    },
-    {
-      id: 'pro',
-      name: 'Pro',
-      price: 149,
-      description: 'Pour les équipes qui grandissent',
-      features: [
-        'Jusqu\'à 3 modules',
-        '5 utilisateurs',
-        'Support prioritaire',
-        '10 GB de stockage',
-        'Intégrations avancées',
-        'Rapports détaillés'
-      ],
-      maxUsers: 5,
-      maxModules: 3,
-      popular: true
-    },
-    {
-      id: 'business',
-      name: 'Business',
-      price: 299,
-      description: 'Pour les grandes organisations',
-      features: [
-        'Tous les modules',
-        '10 utilisateurs',
-        'Support dédié',
-        '50 GB de stockage',
-        'Personnalisation avancée',
-        'White-label',
-        'API complète'
-      ],
-      maxUsers: 10,
-      maxModules: -1,
-      popular: false
-    }
-  ];
+  // Grille tarifaire unique (cf. src/config/saasPlans.ts)
+  const plans: Plan[] = SAAS_PLANS_LIST;
 
   // Calculer les statistiques d'utilisation des plans
   const planStats = plans.map(plan => {

--- a/src/components/saas/SaaSPlansManager.tsx
+++ b/src/components/saas/SaaSPlansManager.tsx
@@ -17,7 +17,10 @@ import {
 import { useModules, useSaaSData } from "@/hooks/useSaaSData";
 import { type SaasPlan } from "@/config/saasPlans";
 import { useSaasPlans } from "@/hooks/useSaasPlans";
+import { useModulesCatalog } from "@/hooks/useModulesCatalog";
+import type { SaasModule } from "@/services/saasModulesService";
 import SaasPlanEditDialog from "./SaasPlanEditDialog";
+import ModuleEditDialog from "./ModuleEditDialog";
 
 type Plan = SaasPlan;
 
@@ -28,7 +31,10 @@ const SaaSPlansManager = () => {
 
   // Grille tarifaire éditable depuis la DB (cf. table saas_plans + useSaasPlans)
   const { plans, reload: reloadPlans } = useSaasPlans({ includeInactive: true });
+  // Catalogue des modules + socle inclus par plan (modèle hybride)
+  const { catalog, planModules, reload: reloadCatalog } = useModulesCatalog();
   const [editingPlan, setEditingPlan] = useState<SaasPlan | null>(null);
+  const [editingModule, setEditingModule] = useState<SaasModule | null>(null);
 
   // Calculer les statistiques d'utilisation des plans
   const planStats = plans.map(plan => {
@@ -247,7 +253,14 @@ const SaaSPlansManager = () => {
                           {module.is_core ? 'Dans tous les plans' : 'Module additionnel'}
                         </div>
                       </div>
-                      <Button variant="outline" size="sm">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => {
+                          const m = catalog.find((c) => c.slug === module.slug);
+                          if (m) setEditingModule(m);
+                        }}
+                      >
                         <Edit className="h-3 w-3 mr-1" />
                         Modifier
                       </Button>
@@ -276,10 +289,24 @@ const SaaSPlansManager = () => {
       {editingPlan && (
         <SaasPlanEditDialog
           plan={editingPlan}
+          catalog={catalog}
+          includedSlugs={planModules[editingPlan.id] ?? []}
           onClose={() => setEditingPlan(null)}
           onSaved={() => {
             setEditingPlan(null);
             reloadPlans();
+            reloadCatalog();
+          }}
+        />
+      )}
+
+      {editingModule && (
+        <ModuleEditDialog
+          module={editingModule}
+          onClose={() => setEditingModule(null)}
+          onSaved={() => {
+            setEditingModule(null);
+            reloadCatalog();
           }}
         />
       )}

--- a/src/components/saas/SaaSPlansManager.tsx
+++ b/src/components/saas/SaaSPlansManager.tsx
@@ -15,7 +15,9 @@ import {
   Zap
 } from "lucide-react";
 import { useModules, useSaaSData } from "@/hooks/useSaaSData";
-import { SAAS_PLANS_LIST, type SaasPlan } from "@/config/saasPlans";
+import { type SaasPlan } from "@/config/saasPlans";
+import { useSaasPlans } from "@/hooks/useSaasPlans";
+import SaasPlanEditDialog from "./SaasPlanEditDialog";
 
 type Plan = SaasPlan;
 
@@ -24,8 +26,9 @@ const SaaSPlansManager = () => {
   const { modules, loading: modulesLoading } = useModules();
   const { companies } = useSaaSData();
 
-  // Grille tarifaire unique (cf. src/config/saasPlans.ts)
-  const plans: Plan[] = SAAS_PLANS_LIST;
+  // Grille tarifaire éditable depuis la DB (cf. table saas_plans + useSaasPlans)
+  const { plans, reload: reloadPlans } = useSaasPlans({ includeInactive: true });
+  const [editingPlan, setEditingPlan] = useState<SaasPlan | null>(null);
 
   // Calculer les statistiques d'utilisation des plans
   const planStats = plans.map(plan => {
@@ -149,7 +152,7 @@ const SaaSPlansManager = () => {
                   </div>
 
                   <div className="flex space-x-2">
-                    <Button variant="outline" size="sm" className="flex-1">
+                    <Button variant="outline" size="sm" className="flex-1" onClick={() => setEditingPlan(plan)}>
                       <Edit className="h-3 w-3 mr-1" />
                       Modifier
                     </Button>
@@ -268,6 +271,17 @@ const SaaSPlansManager = () => {
             </CardContent>
           </Card>
         </div>
+      )}
+
+      {editingPlan && (
+        <SaasPlanEditDialog
+          plan={editingPlan}
+          onClose={() => setEditingPlan(null)}
+          onSaved={() => {
+            setEditingPlan(null);
+            reloadPlans();
+          }}
+        />
       )}
     </div>
   );

--- a/src/components/saas/SaasPlanEditDialog.tsx
+++ b/src/components/saas/SaasPlanEditDialog.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import { Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import type { SaasPlan } from "@/config/saasPlans";
+import { updateSaasPlan } from "@/services/saasPlansService";
+
+interface Props {
+  plan: SaasPlan;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+/** Édition d'un plan tarifaire SaaS (réservé au super_admin via RLS). */
+const SaasPlanEditDialog: React.FC<Props> = ({ plan, onClose, onSaved }) => {
+  const [name, setName] = useState(plan.name);
+  const [price, setPrice] = useState(String(plan.price)); // euros, saisie admin
+  const [description, setDescription] = useState(plan.description);
+  const [features, setFeatures] = useState(plan.features.join("\n"));
+  const [maxUsers, setMaxUsers] = useState(String(plan.maxUsers));
+  const [maxModules, setMaxModules] = useState(String(plan.maxModules));
+  const [popular, setPopular] = useState(plan.popular);
+  const [saving, setSaving] = useState(false);
+
+  const handleSave = async () => {
+    const priceEuros = Number(price.replace(",", "."));
+    if (!name.trim() || Number.isNaN(priceEuros) || priceEuros < 0) {
+      toast.error("Nom et prix valides requis.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await updateSaasPlan(plan.id, {
+        name: name.trim(),
+        priceCents: Math.round(priceEuros * 100),
+        description: description.trim(),
+        features: features.split("\n").map((f) => f.trim()).filter(Boolean),
+        maxUsers: parseInt(maxUsers, 10) || -1,
+        maxModules: parseInt(maxModules, 10) || -1,
+        popular,
+        isActive: true,
+      });
+      if (res.success) {
+        toast.success(`Plan ${name} mis à jour.`);
+        onSaved();
+      } else {
+        toast.error(res.error || "Échec de la mise à jour.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Modifier le plan {plan.name}</DialogTitle>
+          <DialogDescription>
+            La nouvelle grille s'applique immédiatement aux écrans d'abonnement et
+            au montant prélevé par Mollie pour les futures souscriptions.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="plan-name">Nom</Label>
+              <Input id="plan-name" value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="plan-price">Prix (€/mois)</Label>
+              <Input id="plan-price" inputMode="decimal" value={price} onChange={(e) => setPrice(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="plan-desc">Description</Label>
+            <Input id="plan-desc" value={description} onChange={(e) => setDescription(e.target.value)} />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="plan-users">Max utilisateurs (-1 = illimité)</Label>
+              <Input id="plan-users" inputMode="numeric" value={maxUsers} onChange={(e) => setMaxUsers(e.target.value)} />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="plan-modules">Max modules (-1 = illimité)</Label>
+              <Input id="plan-modules" inputMode="numeric" value={maxModules} onChange={(e) => setMaxModules(e.target.value)} />
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="plan-features">Fonctionnalités (une par ligne)</Label>
+            <Textarea id="plan-features" rows={4} value={features} onChange={(e) => setFeatures(e.target.value)} />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Switch id="plan-popular" checked={popular} onCheckedChange={setPopular} />
+            <Label htmlFor="plan-popular">Marquer comme « Populaire »</Label>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} disabled={saving}>
+            Annuler
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+            Enregistrer
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default SaasPlanEditDialog;

--- a/src/components/saas/SaasPlanEditDialog.tsx
+++ b/src/components/saas/SaasPlanEditDialog.tsx
@@ -12,19 +12,23 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
 import { Switch } from "@/components/ui/switch";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import type { SaasPlan } from "@/config/saasPlans";
 import { updateSaasPlan } from "@/services/saasPlansService";
+import { setPlanModules, moduleTierPrice, type SaasModule } from "@/services/saasModulesService";
 
 interface Props {
   plan: SaasPlan;
+  catalog: SaasModule[];
+  includedSlugs: string[];
   onClose: () => void;
   onSaved: () => void;
 }
 
 /** Édition d'un plan tarifaire SaaS (réservé au super_admin via RLS). */
-const SaasPlanEditDialog: React.FC<Props> = ({ plan, onClose, onSaved }) => {
+const SaasPlanEditDialog: React.FC<Props> = ({ plan, catalog, includedSlugs, onClose, onSaved }) => {
   const [name, setName] = useState(plan.name);
   const [price, setPrice] = useState(String(plan.price)); // euros, saisie admin
   const [description, setDescription] = useState(plan.description);
@@ -32,7 +36,12 @@ const SaasPlanEditDialog: React.FC<Props> = ({ plan, onClose, onSaved }) => {
   const [maxUsers, setMaxUsers] = useState(String(plan.maxUsers));
   const [maxModules, setMaxModules] = useState(String(plan.maxModules));
   const [popular, setPopular] = useState(plan.popular);
+  // Modules inclus dans ce plan (les "core" sont toujours inclus implicitement).
+  const [included, setIncluded] = useState<string[]>(includedSlugs);
   const [saving, setSaving] = useState(false);
+
+  const toggleIncluded = (slug: string) =>
+    setIncluded((prev) => (prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug]));
 
   const handleSave = async () => {
     const priceEuros = Number(price.replace(",", "."));
@@ -52,12 +61,18 @@ const SaasPlanEditDialog: React.FC<Props> = ({ plan, onClose, onSaved }) => {
         popular,
         isActive: true,
       });
-      if (res.success) {
-        toast.success(`Plan ${name} mis à jour.`);
-        onSaved();
-      } else {
+      if (!res.success) {
         toast.error(res.error || "Échec de la mise à jour.");
+        return;
       }
+      // Persister le socle de modules inclus dans le plan.
+      const modRes = await setPlanModules(plan.id, included);
+      if (!modRes.success) {
+        toast.error(modRes.error || "Plan enregistré, mais modules inclus non sauvegardés.");
+        return;
+      }
+      toast.success(`Plan ${name} mis à jour.`);
+      onSaved();
     } finally {
       setSaving(false);
     }
@@ -105,6 +120,32 @@ const SaasPlanEditDialog: React.FC<Props> = ({ plan, onClose, onSaved }) => {
           <div className="space-y-1.5">
             <Label htmlFor="plan-features">Fonctionnalités (une par ligne)</Label>
             <Textarea id="plan-features" rows={4} value={features} onChange={(e) => setFeatures(e.target.value)} />
+          </div>
+
+          <div className="space-y-2">
+            <Label>Modules inclus dans ce plan</Label>
+            <p className="text-xs text-muted-foreground">
+              Les modules « core » sont inclus partout. Les modules non cochés restent
+              disponibles en add-on payant (prix du tier indiqué).
+            </p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5 max-h-48 overflow-y-auto rounded-md border p-2">
+              {catalog.map((m) => {
+                const addOn = moduleTierPrice(m, plan.id);
+                return (
+                  <label key={m.slug} className="flex items-center gap-2 text-sm py-0.5">
+                    <Checkbox
+                      checked={m.isCore || included.includes(m.slug)}
+                      disabled={m.isCore}
+                      onCheckedChange={() => toggleIncluded(m.slug)}
+                    />
+                    <span className={m.isCore ? "text-muted-foreground" : ""}>
+                      {m.name}
+                      {m.isCore ? " (core)" : addOn > 0 ? ` · add-on ${addOn} €` : ""}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
           </div>
 
           <div className="flex items-center gap-2">

--- a/src/components/subscription/SubscriptionBanner.tsx
+++ b/src/components/subscription/SubscriptionBanner.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import { AlertTriangle, Clock } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useSubscriptionStatus } from "@/hooks/useSubscriptionStatus";
+
+/**
+ * Bandeau de fin d'essai (blocage doux).
+ * - Essai en cours : rappel discret du nombre de jours restants.
+ * - Essai expiré sans abonnement : bandeau bloquant avec CTA d'upgrade.
+ *
+ * Le passage effectif en lecture seule s'appuie sur `isReadOnly`
+ * (useSubscriptionStatus) au niveau des écrans/mutations.
+ */
+const SubscriptionBanner: React.FC = () => {
+  const navigate = useNavigate();
+  const { loading, isExpired, isTrial, trialDaysLeft } = useSubscriptionStatus();
+
+  if (loading) return null;
+
+  if (isExpired) {
+    return (
+      <div className="w-full bg-destructive/10 border-b border-destructive/30 px-4 py-2.5 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2 text-sm text-destructive">
+          <AlertTriangle className="h-4 w-4 shrink-0" />
+          <span>
+            Votre période d'essai est terminée. Votre compte est en{" "}
+            <strong>lecture seule</strong> — choisissez un plan pour réactiver l'écriture.
+          </span>
+        </div>
+        <Button size="sm" variant="destructive" onClick={() => navigate("/settings/subscription")}>
+          Choisir un plan
+        </Button>
+      </div>
+    );
+  }
+
+  if (isTrial && trialDaysLeft <= 7) {
+    return (
+      <div className="w-full bg-amber-50 border-b border-amber-200 px-4 py-2 flex items-center justify-between gap-4">
+        <div className="flex items-center gap-2 text-sm text-amber-800">
+          <Clock className="h-4 w-4 shrink-0" />
+          <span>
+            {trialDaysLeft > 0
+              ? `Votre essai se termine dans ${trialDaysLeft} jour${trialDaysLeft > 1 ? "s" : ""}.`
+              : "Votre essai se termine aujourd'hui."}
+          </span>
+        </div>
+        <Button size="sm" variant="outline" onClick={() => navigate("/settings/subscription")}>
+          S'abonner
+        </Button>
+      </div>
+    );
+  }
+
+  return null;
+};
+
+export default SubscriptionBanner;

--- a/src/config/saasPlans.ts
+++ b/src/config/saasPlans.ts
@@ -1,0 +1,81 @@
+/**
+ * Source de vérité UNIQUE des plans d'abonnement SaaS Leazr.
+ *
+ * Avant ce fichier, la grille tarifaire était dupliquée et contradictoire dans
+ * au moins 4 endroits (companyService.PLANS, SaaSPlansManager, CompanySubscriptionPage,
+ * create-checkout). Tous ces consommateurs doivent désormais importer d'ici.
+ *
+ * Tarifs officiels (mensuel HT) : Starter 79 € · Pro 129 € · Business 199 €.
+ * Facturation via Mollie (cf. edge function mollie-saas-subscribe).
+ */
+
+export type SaasPlanId = "starter" | "pro" | "business";
+
+export interface SaasPlan {
+  id: SaasPlanId;
+  name: string;
+  /** Prix mensuel HT en euros. */
+  price: number;
+  /** Prix en centimes — ce que Mollie attend. */
+  priceCents: number;
+  description: string;
+  features: string[];
+  /** Nombre max d'utilisateurs. -1 = illimité. */
+  maxUsers: number;
+  /** Nombre max de modules activables. -1 = illimité (tous). */
+  maxModules: number;
+  popular: boolean;
+}
+
+export const SAAS_PLANS: Record<SaasPlanId, SaasPlan> = {
+  starter: {
+    id: "starter",
+    name: "Starter",
+    price: 79,
+    priceCents: 7900,
+    description: "Pour débuter",
+    features: ["1 utilisateur", "1 module", "Support par email"],
+    maxUsers: 1,
+    maxModules: 1,
+    popular: false,
+  },
+  pro: {
+    id: "pro",
+    name: "Pro",
+    price: 129,
+    priceCents: 12900,
+    description: "Pour grandir",
+    features: ["5 utilisateurs", "3 modules", "Support prioritaire"],
+    maxUsers: 5,
+    maxModules: 3,
+    popular: true,
+  },
+  business: {
+    id: "business",
+    name: "Business",
+    price: 199,
+    priceCents: 19900,
+    description: "Pour l'entreprise",
+    features: ["10 utilisateurs", "Tous les modules", "Support dédié"],
+    maxUsers: 10,
+    maxModules: -1,
+    popular: false,
+  },
+};
+
+/** Liste ordonnée (pour l'affichage des grilles tarifaires). */
+export const SAAS_PLANS_LIST: SaasPlan[] = [
+  SAAS_PLANS.starter,
+  SAAS_PLANS.pro,
+  SAAS_PLANS.business,
+];
+
+export const isSaasPlanId = (value: unknown): value is SaasPlanId =>
+  typeof value === "string" && value in SAAS_PLANS;
+
+/** Retourne le plan, avec repli sur Starter si la valeur est inconnue/nulle. */
+export const getSaasPlan = (planId: string | null | undefined): SaasPlan =>
+  isSaasPlanId(planId) ? SAAS_PLANS[planId] : SAAS_PLANS.starter;
+
+/** Durée d'essai en jours (aligné avec create-company-with-admin / dataIsolationService). */
+export const TRIAL_DURATION_DAYS = 14;

--- a/src/hooks/useModulesCatalog.ts
+++ b/src/hooks/useModulesCatalog.ts
@@ -1,0 +1,32 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  fetchModulesCatalog,
+  fetchPlanModules,
+  type SaasModule,
+} from "@/services/saasModulesService";
+
+/**
+ * Catalogue global des modules Leazr + modules inclus par plan (socle hybride).
+ */
+export const useModulesCatalog = () => {
+  const [catalog, setCatalog] = useState<SaasModule[]>([]);
+  const [planModules, setPlanModules] = useState<Record<string, string[]>>({});
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [cat, pm] = await Promise.all([fetchModulesCatalog(), fetchPlanModules()]);
+      setCatalog(cat);
+      setPlanModules(pm);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return { catalog, planModules, loading, reload };
+};

--- a/src/hooks/useSaasPlans.ts
+++ b/src/hooks/useSaasPlans.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from "react";
+import { SAAS_PLANS_LIST, type SaasPlan } from "@/config/saasPlans";
+import { fetchSaasPlans } from "@/services/saasPlansService";
+
+/**
+ * Grille tarifaire SaaS depuis la DB (éditable par le super_admin), avec repli
+ * immédiat sur la constante typée le temps du chargement / en cas d'erreur.
+ */
+export const useSaasPlans = (opts?: { includeInactive?: boolean }) => {
+  const [plans, setPlans] = useState<SaasPlan[]>(SAAS_PLANS_LIST);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    setLoading(true);
+    try {
+      const data = await fetchSaasPlans(opts);
+      setPlans(data);
+    } finally {
+      setLoading(false);
+    }
+  }, [opts?.includeInactive]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  return { plans, loading, reload };
+};

--- a/src/hooks/useSubscriptionStatus.ts
+++ b/src/hooks/useSubscriptionStatus.ts
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+import { getCurrentUserCompanyId } from "@/services/multiTenantService";
+import {
+  fetchCompanySubscriptionState,
+  type AccountStatus,
+} from "@/services/saasSubscriptionService";
+
+export interface SubscriptionStatus {
+  loading: boolean;
+  status: AccountStatus | null;
+  plan: string | null;
+  /** true quand l'essai est terminé sans abonnement → blocage doux. */
+  isExpired: boolean;
+  isTrial: boolean;
+  /** Jours restants d'essai (0 si expiré / non applicable). */
+  trialDaysLeft: number;
+  /** L'app devrait passer en lecture seule quand true. */
+  isReadOnly: boolean;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * État d'abonnement de la company courante, pour le blocage doux de fin d'essai
+ * (bandeau d'upgrade + lecture seule). Ne bloque rien tout seul : expose les
+ * drapeaux que la bannière et les écrans consomment.
+ */
+export const useSubscriptionStatus = (): SubscriptionStatus => {
+  const [state, setState] = useState<SubscriptionStatus>({
+    loading: true,
+    status: null,
+    plan: null,
+    isExpired: false,
+    isTrial: false,
+    trialDaysLeft: 0,
+    isReadOnly: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const companyId = await getCurrentUserCompanyId();
+        if (!companyId) {
+          if (!cancelled) setState((s) => ({ ...s, loading: false }));
+          return;
+        }
+        const sub = await fetchCompanySubscriptionState(companyId);
+        if (cancelled) return;
+
+        const status = (sub?.account_status ?? null) as AccountStatus | null;
+        const trialEnds = sub?.trial_ends_at ? new Date(sub.trial_ends_at).getTime() : null;
+        const now = Date.now();
+
+        const isTrial = status === "trial";
+        const trialDaysLeft =
+          isTrial && trialEnds ? Math.max(0, Math.ceil((trialEnds - now) / DAY_MS)) : 0;
+        // Expiré si le statut le dit, ou si l'essai est dépassé sans abonnement
+        // (filet en attendant le passage du cron expire_overdue_trials).
+        const isExpired =
+          status === "expired" ||
+          (isTrial && !!trialEnds && trialEnds < now && !sub?.mollie_subscription_id);
+
+        setState({
+          loading: false,
+          status,
+          plan: sub?.plan ?? null,
+          isExpired,
+          isTrial,
+          trialDaysLeft,
+          isReadOnly: isExpired,
+        });
+      } catch {
+        if (!cancelled) setState((s) => ({ ...s, loading: false }));
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+};

--- a/src/pages/CompanySubscriptionPage.tsx
+++ b/src/pages/CompanySubscriptionPage.tsx
@@ -29,13 +29,15 @@ import { motion } from "framer-motion";
 import { useCompanyDetails } from "@/hooks/useCompanyDetails";
 import { updateCompanyPlan } from "@/services/companyModulesService";
 import CompanyModulesManager from "@/components/saas/CompanyModulesManager";
+import { SAAS_PLANS_LIST } from "@/config/saasPlans";
 
-const available_plans = [
-  { id: 'starter', name: 'Starter', price: 49, features: ['5 utilisateurs', 'CRM de base'] },
-  { id: 'pro', name: 'Pro', price: 149, features: ['20 utilisateurs', 'CRM avancé', 'Analytics'] },
-  { id: 'business', name: 'Business', price: 299, features: ['50 utilisateurs', 'Toutes fonctionnalités'] },
-  { id: 'enterprise', name: 'Enterprise', price: 599, features: ['Utilisateurs illimités', 'Support dédié'] }
-];
+// Grille tarifaire unique (cf. src/config/saasPlans.ts)
+const available_plans = SAAS_PLANS_LIST.map((p) => ({
+  id: p.id,
+  name: p.name,
+  price: p.price,
+  features: p.features,
+}));
 
 
 const CompanySubscriptionPage = () => {

--- a/src/pages/SubscriptionSettings.tsx
+++ b/src/pages/SubscriptionSettings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -9,21 +9,57 @@ import { toast } from "sonner";
 import Container from "@/components/layout/Container";
 import { type SaasPlanId } from "@/config/saasPlans";
 import { useSaasPlans } from "@/hooks/useSaasPlans";
-import { subscribeToPlan } from "@/services/saasSubscriptionService";
+import { useModulesCatalog } from "@/hooks/useModulesCatalog";
+import { computeMonthlyPrice } from "@/services/saasModulesService";
+import {
+  subscribeToPlan,
+  fetchCompanyModulesEnabled,
+} from "@/services/saasSubscriptionService";
+import { getCurrentUserCompanyId } from "@/services/multiTenantService";
 import { useSubscriptionStatus } from "@/hooks/useSubscriptionStatus";
 
 /**
  * Page d'abonnement côté ENTREPRISE cliente : choix du plan + mandat SEPA (IBAN)
  * → souscription Mollie récurrente. Réactive le compte en fin d'essai.
+ * Affiche le détail tarifaire hybride : base du plan + add-ons modules.
  */
 const SubscriptionSettings: React.FC = () => {
   const { status, plan: currentPlan } = useSubscriptionStatus();
   const { plans } = useSaasPlans();
+  const { catalog, planModules } = useModulesCatalog();
+  const [enabledModules, setEnabledModules] = useState<string[]>([]);
   const [selected, setSelected] = useState<SaasPlanId>("pro");
   const [accountHolder, setAccountHolder] = useState("");
   const [iban, setIban] = useState("");
   const [bic, setBic] = useState("");
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const companyId = await getCurrentUserCompanyId();
+      if (!companyId || cancelled) return;
+      const mods = await fetchCompanyModulesEnabled(companyId);
+      if (!cancelled) setEnabledModules(mods);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectedPlan = plans.find((p) => p.id === selected);
+
+  // Détail tarifaire hybride pour le plan sélectionné.
+  const pricing = useMemo(() => {
+    if (!selectedPlan) return { total: 0, addOns: [] as { slug: string; name: string; price: number }[] };
+    return computeMonthlyPrice({
+      planId: selected,
+      planBasePrice: selectedPlan.price,
+      includedSlugs: planModules[selected] ?? [],
+      enabledSlugs: enabledModules,
+      catalog,
+    });
+  }, [selectedPlan, selected, planModules, enabledModules, catalog]);
 
   const handleSubscribe = async () => {
     if (!accountHolder.trim() || !iban.trim()) {
@@ -138,9 +174,28 @@ const SubscriptionSettings: React.FC = () => {
                 placeholder="BE00 0000 0000 0000"
               />
             </div>
+
+            {/* Détail tarifaire hybride : base du plan + add-ons modules */}
+            <div className="rounded-md border p-3 text-sm space-y-1.5 bg-muted/40">
+              <div className="flex justify-between">
+                <span>Plan {selectedPlan?.name}</span>
+                <span>{selectedPlan?.price ?? 0} €</span>
+              </div>
+              {pricing.addOns.map((a) => (
+                <div key={a.slug} className="flex justify-between text-muted-foreground">
+                  <span>+ {a.name} (add-on)</span>
+                  <span>{a.price} €</span>
+                </div>
+              ))}
+              <div className="flex justify-between font-semibold border-t pt-1.5 mt-1.5">
+                <span>Total mensuel</span>
+                <span>{pricing.total} € / mois</span>
+              </div>
+            </div>
+
             <Button onClick={handleSubscribe} disabled={submitting}>
               {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-              S'abonner au plan {plans.find((p) => p.id === selected)?.name}
+              S'abonner — {pricing.total} € / mois
             </Button>
           </CardContent>
         </Card>

--- a/src/pages/SubscriptionSettings.tsx
+++ b/src/pages/SubscriptionSettings.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Check, Loader2, Star } from "lucide-react";
+import { toast } from "sonner";
+import Container from "@/components/layout/Container";
+import { SAAS_PLANS_LIST, type SaasPlanId } from "@/config/saasPlans";
+import { subscribeToPlan } from "@/services/saasSubscriptionService";
+import { useSubscriptionStatus } from "@/hooks/useSubscriptionStatus";
+
+/**
+ * Page d'abonnement côté ENTREPRISE cliente : choix du plan + mandat SEPA (IBAN)
+ * → souscription Mollie récurrente. Réactive le compte en fin d'essai.
+ */
+const SubscriptionSettings: React.FC = () => {
+  const { status, plan: currentPlan } = useSubscriptionStatus();
+  const [selected, setSelected] = useState<SaasPlanId>("pro");
+  const [accountHolder, setAccountHolder] = useState("");
+  const [iban, setIban] = useState("");
+  const [bic, setBic] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubscribe = async () => {
+    if (!accountHolder.trim() || !iban.trim()) {
+      toast.error("Titulaire et IBAN sont requis.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await subscribeToPlan({
+        plan: selected,
+        iban: iban.trim(),
+        accountHolder: accountHolder.trim(),
+        bic: bic.trim() || undefined,
+      });
+      if (res.success) {
+        toast.success("Abonnement créé. Votre compte est réactivé.");
+      } else {
+        toast.error(res.error || "Échec de la souscription.");
+      }
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : "Erreur inattendue.");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Container>
+      <div className="py-8 max-w-4xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-2xl font-semibold">Abonnement</h1>
+          <p className="text-muted-foreground">
+            Choisissez votre plan et activez le prélèvement SEPA.
+            {status && (
+              <>
+                {" "}Statut actuel : <Badge variant="outline">{status}</Badge>
+                {currentPlan ? ` · plan ${currentPlan}` : ""}
+              </>
+            )}
+          </p>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {SAAS_PLANS_LIST.map((p) => {
+            const isSelected = selected === p.id;
+            return (
+              <Card
+                key={p.id}
+                role="button"
+                onClick={() => setSelected(p.id)}
+                className={`cursor-pointer transition ${isSelected ? "ring-2 ring-primary" : "hover:border-primary/50"}`}
+              >
+                <CardHeader>
+                  <div className="flex items-center justify-between">
+                    <CardTitle>{p.name}</CardTitle>
+                    {p.popular && (
+                      <Badge className="gap-1">
+                        <Star className="h-3 w-3" /> Populaire
+                      </Badge>
+                    )}
+                  </div>
+                  <CardDescription>{p.description}</CardDescription>
+                  <div className="text-2xl font-bold">
+                    {p.price} € <span className="text-sm font-normal text-muted-foreground">/ mois</span>
+                  </div>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-1.5 text-sm">
+                    {p.features.map((f) => (
+                      <li key={f} className="flex items-center gap-2">
+                        <Check className="h-4 w-4 text-primary shrink-0" />
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Mandat de prélèvement SEPA</CardTitle>
+            <CardDescription>
+              Le montant du plan {SAAS_PLANS_LIST.find((p) => p.id === selected)?.name} sera prélevé
+              chaque mois via Mollie.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="holder">Titulaire du compte</Label>
+                <Input
+                  id="holder"
+                  value={accountHolder}
+                  onChange={(e) => setAccountHolder(e.target.value)}
+                  placeholder="Nom du titulaire"
+                />
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="bic">BIC (optionnel)</Label>
+                <Input id="bic" value={bic} onChange={(e) => setBic(e.target.value)} placeholder="GEBABEBB" />
+              </div>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="iban">IBAN</Label>
+              <Input
+                id="iban"
+                value={iban}
+                onChange={(e) => setIban(e.target.value)}
+                placeholder="BE00 0000 0000 0000"
+              />
+            </div>
+            <Button onClick={handleSubscribe} disabled={submitting}>
+              {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+              S'abonner au plan {SAAS_PLANS_LIST.find((p) => p.id === selected)?.name}
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </Container>
+  );
+};
+
+export default SubscriptionSettings;

--- a/src/pages/SubscriptionSettings.tsx
+++ b/src/pages/SubscriptionSettings.tsx
@@ -7,7 +7,8 @@ import { Label } from "@/components/ui/label";
 import { Check, Loader2, Star } from "lucide-react";
 import { toast } from "sonner";
 import Container from "@/components/layout/Container";
-import { SAAS_PLANS_LIST, type SaasPlanId } from "@/config/saasPlans";
+import { type SaasPlanId } from "@/config/saasPlans";
+import { useSaasPlans } from "@/hooks/useSaasPlans";
 import { subscribeToPlan } from "@/services/saasSubscriptionService";
 import { useSubscriptionStatus } from "@/hooks/useSubscriptionStatus";
 
@@ -17,6 +18,7 @@ import { useSubscriptionStatus } from "@/hooks/useSubscriptionStatus";
  */
 const SubscriptionSettings: React.FC = () => {
   const { status, plan: currentPlan } = useSubscriptionStatus();
+  const { plans } = useSaasPlans();
   const [selected, setSelected] = useState<SaasPlanId>("pro");
   const [accountHolder, setAccountHolder] = useState("");
   const [iban, setIban] = useState("");
@@ -65,7 +67,7 @@ const SubscriptionSettings: React.FC = () => {
         </div>
 
         <div className="grid gap-4 md:grid-cols-3">
-          {SAAS_PLANS_LIST.map((p) => {
+          {plans.map((p) => {
             const isSelected = selected === p.id;
             return (
               <Card
@@ -107,7 +109,7 @@ const SubscriptionSettings: React.FC = () => {
           <CardHeader>
             <CardTitle>Mandat de prélèvement SEPA</CardTitle>
             <CardDescription>
-              Le montant du plan {SAAS_PLANS_LIST.find((p) => p.id === selected)?.name} sera prélevé
+              Le montant du plan {plans.find((p) => p.id === selected)?.name} sera prélevé
               chaque mois via Mollie.
             </CardDescription>
           </CardHeader>
@@ -138,7 +140,7 @@ const SubscriptionSettings: React.FC = () => {
             </div>
             <Button onClick={handleSubscribe} disabled={submitting}>
               {submitting && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
-              S'abonner au plan {SAAS_PLANS_LIST.find((p) => p.id === selected)?.name}
+              S'abonner au plan {plans.find((p) => p.id === selected)?.name}
             </Button>
           </CardContent>
         </Card>

--- a/src/services/companyService.ts
+++ b/src/services/companyService.ts
@@ -28,10 +28,14 @@ export interface Plan {
   popular?: boolean;
 }
 
+// Grille tarifaire dérivée de la source de vérité unique (src/config/saasPlans.ts).
+// L'export `PLANS` est conservé pour compatibilité avec les imports existants.
+import { SAAS_PLANS } from "@/config/saasPlans";
+
 export const PLANS = {
-  starter: { name: "Starter", price: 29, description: "Pour débuter", features: ["5 utilisateurs", "Support basique"], popular: false },
-  pro: { name: "Pro", price: 79, description: "Pour grandir", features: ["25 utilisateurs", "Support prioritaire"], popular: true },
-  business: { name: "Business", price: 149, description: "Pour l'entreprise", features: ["Utilisateurs illimités", "Support dédié"], popular: false }
+  starter: { name: SAAS_PLANS.starter.name, price: SAAS_PLANS.starter.price, description: SAAS_PLANS.starter.description, features: SAAS_PLANS.starter.features, popular: SAAS_PLANS.starter.popular },
+  pro: { name: SAAS_PLANS.pro.name, price: SAAS_PLANS.pro.price, description: SAAS_PLANS.pro.description, features: SAAS_PLANS.pro.features, popular: SAAS_PLANS.pro.popular },
+  business: { name: SAAS_PLANS.business.name, price: SAAS_PLANS.business.price, description: SAAS_PLANS.business.description, features: SAAS_PLANS.business.features, popular: SAAS_PLANS.business.popular },
 };
 
 export const getCompanyByOfferId = async (offerId: string): Promise<CompanyInfo | null> => {

--- a/src/services/saasModulesService.ts
+++ b/src/services/saasModulesService.ts
@@ -1,0 +1,134 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { SaasPlanId } from "@/config/saasPlans";
+
+export interface SaasModule {
+  slug: string;
+  name: string;
+  description: string;
+  isCore: boolean;
+  priceStarter: number; // €/mois en add-on sur le plan Starter
+  pricePro: number;
+  priceBusiness: number;
+}
+
+export interface EditableModuleFields {
+  name: string;
+  description: string;
+  isCore: boolean;
+  priceStarter: number;
+  pricePro: number;
+  priceBusiness: number;
+}
+
+interface ModuleRow {
+  slug: string;
+  name: string;
+  description: string | null;
+  is_core: boolean;
+  price_starter: number | null;
+  price_pro: number | null;
+  price_business: number | null;
+}
+
+const rowToModule = (r: ModuleRow): SaasModule => ({
+  slug: r.slug,
+  name: r.name,
+  description: r.description ?? "",
+  isCore: r.is_core,
+  priceStarter: Number(r.price_starter ?? 0),
+  pricePro: Number(r.price_pro ?? 0),
+  priceBusiness: Number(r.price_business ?? 0),
+});
+
+/** Catalogue global des modules Leazr. */
+export const fetchModulesCatalog = async (): Promise<SaasModule[]> => {
+  const { data, error } = await supabase
+    .from("modules")
+    .select("slug, name, description, is_core, price_starter, price_pro, price_business")
+    .order("is_core", { ascending: false })
+    .order("name", { ascending: true });
+  if (error || !data) return [];
+  return (data as ModuleRow[]).map(rowToModule);
+};
+
+/** Met à jour un module (réservé au super_admin via RLS). */
+export const updateModule = async (
+  slug: string,
+  fields: EditableModuleFields,
+): Promise<{ success: boolean; error?: string }> => {
+  const { error } = await supabase
+    .from("modules")
+    .update({
+      name: fields.name,
+      description: fields.description,
+      is_core: fields.isCore,
+      price_starter: fields.priceStarter,
+      price_pro: fields.pricePro,
+      price_business: fields.priceBusiness,
+    })
+    .eq("slug", slug);
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+};
+
+/** Modules inclus (socle) par plan : { planId: [slug, ...] }. */
+export const fetchPlanModules = async (): Promise<Record<string, string[]>> => {
+  const { data, error } = await supabase
+    .from("plan_modules")
+    .select("plan_id, module_slug");
+  if (error || !data) return {};
+  return data.reduce((acc: Record<string, string[]>, row: any) => {
+    (acc[row.plan_id] ??= []).push(row.module_slug);
+    return acc;
+  }, {});
+};
+
+/** Remplace l'ensemble des modules inclus d'un plan (super_admin). */
+export const setPlanModules = async (
+  planId: SaasPlanId,
+  slugs: string[],
+): Promise<{ success: boolean; error?: string }> => {
+  const { error: delErr } = await supabase.from("plan_modules").delete().eq("plan_id", planId);
+  if (delErr) return { success: false, error: delErr.message };
+  if (slugs.length > 0) {
+    const rows = slugs.map((module_slug) => ({ plan_id: planId, module_slug }));
+    const { error: insErr } = await supabase.from("plan_modules").insert(rows);
+    if (insErr) return { success: false, error: insErr.message };
+  }
+  return { success: true };
+};
+
+/** Prix d'un module pour un tier donné. */
+export const moduleTierPrice = (m: SaasModule, planId: SaasPlanId): number => {
+  if (planId === "pro") return m.pricePro;
+  if (planId === "business") return m.priceBusiness;
+  return m.priceStarter;
+};
+
+/**
+ * Coût mensuel HYBRIDE (en euros) = prix de base du plan
+ *   + somme des add-ons (modules activés qui ne sont NI core NI inclus dans le plan),
+ *     facturés au tarif du tier.
+ */
+export const computeMonthlyPrice = (params: {
+  planId: SaasPlanId;
+  planBasePrice: number;
+  includedSlugs: string[];
+  enabledSlugs: string[];
+  catalog: SaasModule[];
+}): { total: number; addOns: { slug: string; name: string; price: number }[] } => {
+  const { planId, planBasePrice, includedSlugs, enabledSlugs, catalog } = params;
+  const included = new Set(includedSlugs);
+  const addOns: { slug: string; name: string; price: number }[] = [];
+
+  for (const m of catalog) {
+    if (m.isCore) continue; // core toujours inclus
+    if (included.has(m.slug)) continue; // déjà inclus dans le plan
+    if (!enabledSlugs.includes(m.slug)) continue; // non activé par le tenant
+    const price = moduleTierPrice(m, planId);
+    if (price > 0) addOns.push({ slug: m.slug, name: m.name, price });
+  }
+
+  const total = planBasePrice + addOns.reduce((s, a) => s + a.price, 0);
+  return { total, addOns };
+};

--- a/src/services/saasPlansService.ts
+++ b/src/services/saasPlansService.ts
@@ -1,0 +1,89 @@
+import { supabase } from "@/integrations/supabase/client";
+import {
+  SAAS_PLANS_LIST,
+  type SaasPlan,
+  type SaasPlanId,
+} from "@/config/saasPlans";
+
+/** Champs éditables d'un plan depuis le SaaS admin. */
+export interface EditableSaasPlanFields {
+  name: string;
+  priceCents: number;
+  description: string;
+  features: string[];
+  maxUsers: number;
+  maxModules: number;
+  popular: boolean;
+  isActive: boolean;
+}
+
+interface SaasPlanRow {
+  plan_id: string;
+  name: string;
+  price_cents: number;
+  description: string | null;
+  features: unknown;
+  max_users: number;
+  max_modules: number;
+  popular: boolean;
+  sort_order: number;
+  is_active: boolean;
+}
+
+const rowToPlan = (r: SaasPlanRow): SaasPlan => ({
+  id: r.plan_id as SaasPlanId,
+  name: r.name,
+  price: Math.round(r.price_cents) / 100,
+  priceCents: r.price_cents,
+  description: r.description ?? "",
+  features: Array.isArray(r.features) ? (r.features as string[]) : [],
+  maxUsers: r.max_users,
+  maxModules: r.max_modules,
+  popular: r.popular,
+});
+
+/**
+ * Récupère la grille tarifaire depuis la DB (source de vérité éditable).
+ * En cas d'erreur / table vide, repli sur la constante typée SAAS_PLANS_LIST.
+ */
+export const fetchSaasPlans = async (
+  opts?: { includeInactive?: boolean },
+): Promise<SaasPlan[]> => {
+  let query = supabase
+    .from("saas_plans")
+    .select("plan_id, name, price_cents, description, features, max_users, max_modules, popular, sort_order, is_active")
+    .order("sort_order", { ascending: true });
+
+  if (!opts?.includeInactive) {
+    query = query.eq("is_active", true);
+  }
+
+  const { data, error } = await query;
+  if (error || !data || data.length === 0) {
+    return SAAS_PLANS_LIST;
+  }
+  return (data as SaasPlanRow[]).map(rowToPlan);
+};
+
+/** Met à jour un plan (réservé au super_admin via RLS). */
+export const updateSaasPlan = async (
+  planId: string,
+  fields: EditableSaasPlanFields,
+): Promise<{ success: boolean; error?: string }> => {
+  const { error } = await supabase
+    .from("saas_plans")
+    .update({
+      name: fields.name,
+      price_cents: fields.priceCents,
+      description: fields.description,
+      features: fields.features,
+      max_users: fields.maxUsers,
+      max_modules: fields.maxModules,
+      popular: fields.popular,
+      is_active: fields.isActive,
+    })
+    .eq("plan_id", planId);
+
+  if (error) return { success: false, error: error.message };
+  return { success: true };
+};

--- a/src/services/saasSubscriptionService.ts
+++ b/src/services/saasSubscriptionService.ts
@@ -1,0 +1,45 @@
+import { supabase } from "@/integrations/supabase/client";
+import type { SaasPlanId } from "@/config/saasPlans";
+
+export type AccountStatus = "trial" | "active" | "expired" | "cancelled";
+
+export interface CompanySubscriptionState {
+  plan: string | null;
+  account_status: AccountStatus | null;
+  trial_ends_at: string | null;
+  subscription_ends_at: string | null;
+  mollie_subscription_id: string | null;
+}
+
+/**
+ * Souscrit l'entreprise de l'utilisateur courant à un plan SaaS via Mollie
+ * (SEPA Direct Debit récurrent). La company est résolue côté serveur depuis le
+ * profil de l'appelant — aucun company_id n'est transmis depuis le client.
+ */
+export const subscribeToPlan = async (params: {
+  plan: SaasPlanId;
+  iban: string;
+  accountHolder: string;
+  bic?: string;
+}): Promise<{ success: boolean; error?: string; mollie_subscription_id?: string }> => {
+  const { data, error } = await supabase.functions.invoke("mollie-saas-subscribe", {
+    body: params,
+  });
+  if (error) {
+    return { success: false, error: error.message };
+  }
+  return data;
+};
+
+/** Lit l'état d'abonnement de la company courante (RLS : sa propre ligne). */
+export const fetchCompanySubscriptionState = async (
+  companyId: string,
+): Promise<CompanySubscriptionState | null> => {
+  const { data, error } = await supabase
+    .from("companies")
+    .select("plan, account_status, trial_ends_at, subscription_ends_at, mollie_subscription_id")
+    .eq("id", companyId)
+    .maybeSingle();
+  if (error || !data) return null;
+  return data as CompanySubscriptionState;
+};

--- a/src/services/saasSubscriptionService.ts
+++ b/src/services/saasSubscriptionService.ts
@@ -31,6 +31,19 @@ export const subscribeToPlan = async (params: {
   return data;
 };
 
+/** Liste des slugs de modules activés pour la company. */
+export const fetchCompanyModulesEnabled = async (
+  companyId: string,
+): Promise<string[]> => {
+  const { data, error } = await supabase
+    .from("companies")
+    .select("modules_enabled")
+    .eq("id", companyId)
+    .maybeSingle();
+  if (error || !data) return [];
+  return Array.isArray((data as any).modules_enabled) ? (data as any).modules_enabled : [];
+};
+
 /** Lit l'état d'abonnement de la company courante (RLS : sa propre ligne). */
 export const fetchCompanySubscriptionState = async (
   companyId: string,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -285,3 +285,7 @@ verify_jwt = true
 [functions.grenke-automation]
 # Cron-driven (X-Cron-Secret); does its own auth.
 verify_jwt = false
+
+[functions.mollie-saas-subscribe]
+# Authenticated SaaS subscription (admin). Does its own auth + company scoping.
+verify_jwt = true

--- a/supabase/functions/mollie-saas-subscribe/index.ts
+++ b/supabase/functions/mollie-saas-subscribe/index.ts
@@ -1,0 +1,168 @@
+/**
+ * mollie-saas-subscribe
+ *
+ * Souscrit l'ENTREPRISE de l'appelant à un plan SaaS Leazr (facturation A :
+ * Leazr → entreprise cliente), via Mollie SEPA Direct Debit récurrent.
+ *
+ * Flux Mollie : customer → mandat SEPA (IBAN) → subscription mensuelle.
+ * À la fin : companies.{mollie_customer_id, mollie_mandate_id,
+ * mollie_subscription_id, plan, account_status='active'} sont mis à jour.
+ *
+ * SÉCURITÉ : la company n'est JAMAIS prise dans le body — elle est dérivée du
+ * profil de l'appelant authentifié, qui doit être admin/super_admin.
+ *
+ * À TESTER EN SANDBOX MOLLIE avant prod (nécessite MOLLIE_API_KEY).
+ */
+import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const MOLLIE_API_URL = "https://api.mollie.com/v2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+// Grille tarifaire — DOIT rester alignée avec src/config/saasPlans.ts.
+const PLAN_PRICE_CENTS: Record<string, number> = {
+  starter: 7900,
+  pro: 12900,
+  business: 19900,
+};
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+async function mollie(path: string, apiKey: string, method = "GET", body?: Record<string, unknown>) {
+  const res = await fetch(`${MOLLIE_API_URL}${path}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const data = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`Mollie ${method} ${path} → ${res.status}: ${JSON.stringify(data)}`);
+  }
+  return data;
+}
+
+serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return json(405, { error: "Method not allowed" });
+
+  try {
+    const apiKey = Deno.env.get("MOLLIE_API_KEY");
+    if (!apiKey) return json(500, { error: "MOLLIE_API_KEY non configurée" });
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+    // ── Auth : identifier l'appelant et sa company (jamais depuis le body) ──
+    const authHeader = req.headers.get("Authorization") || "";
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    if (!token) return json(401, { error: "Non authentifié" });
+
+    const callerClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: `Bearer ${token}` } },
+    });
+    const { data: { user } } = await callerClient.auth.getUser(token);
+    if (!user) return json(401, { error: "Non authentifié" });
+
+    const admin = createClient(supabaseUrl, serviceKey);
+    const { data: profile } = await admin
+      .from("profiles")
+      .select("company_id, role")
+      .eq("id", user.id)
+      .maybeSingle();
+
+    if (!profile?.company_id) return json(403, { error: "Aucune entreprise associée" });
+    if (!["admin", "super_admin"].includes(profile.role)) {
+      return json(403, { error: "Réservé aux administrateurs" });
+    }
+    const companyId: string = profile.company_id;
+
+    // ── Body ──
+    const { plan, iban, accountHolder, bic } = await req.json();
+    const planId = String(plan || "").toLowerCase();
+    const priceCents = PLAN_PRICE_CENTS[planId];
+    if (!priceCents) return json(400, { error: "Plan invalide" });
+    if (!iban || !accountHolder) {
+      return json(400, { error: "iban et accountHolder sont requis" });
+    }
+
+    // ── Company actuelle ──
+    const { data: company } = await admin
+      .from("companies")
+      .select("id, name, mollie_customer_id")
+      .eq("id", companyId)
+      .single();
+    if (!company) return json(404, { error: "Entreprise introuvable" });
+
+    const email = user.email ?? `billing+${companyId}@leazr.co`;
+
+    // 1) Customer Mollie (réutilise l'existant si déjà créé)
+    let customerId = company.mollie_customer_id as string | null;
+    if (!customerId) {
+      const customer = await mollie("/customers", apiKey, "POST", {
+        name: company.name || accountHolder,
+        email,
+        metadata: { company_id: companyId, kind: "saas_subscription" },
+      });
+      customerId = customer.id;
+    }
+
+    // 2) Mandat SEPA direct (IBAN) — pas de redirection
+    const mandate = await mollie(`/customers/${customerId}/mandates`, apiKey, "POST", {
+      method: "directdebit",
+      consumerName: accountHolder,
+      consumerAccount: iban.replace(/\s+/g, ""),
+      ...(bic ? { consumerBic: bic } : {}),
+    });
+
+    // 3) Subscription mensuelle au tarif du plan
+    const value = (priceCents / 100).toFixed(2);
+    const webhookUrl = `${supabaseUrl}/functions/v1/mollie-webhook`;
+    const subscription = await mollie(`/customers/${customerId}/subscriptions`, apiKey, "POST", {
+      amount: { currency: "EUR", value },
+      interval: "1 month",
+      description: `Abonnement Leazr ${planId} — ${company.name ?? companyId}`,
+      mandateId: mandate.id,
+      webhookUrl,
+      metadata: { company_id: companyId, kind: "saas_subscription", plan: planId },
+    });
+
+    // 4) Persister sur la company → tenant activé
+    const { error: updateErr } = await admin
+      .from("companies")
+      .update({
+        mollie_customer_id: customerId,
+        mollie_mandate_id: mandate.id,
+        mollie_subscription_id: subscription.id,
+        plan: planId,
+        account_status: "active",
+        subscription_started_at: new Date().toISOString(),
+      })
+      .eq("id", companyId);
+    if (updateErr) throw new Error(`MAJ company échouée: ${updateErr.message}`);
+
+    return json(200, {
+      success: true,
+      plan: planId,
+      mollie_customer_id: customerId,
+      mollie_mandate_id: mandate.id,
+      mollie_subscription_id: subscription.id,
+      mandate_status: mandate.status,
+    });
+  } catch (e) {
+    console.error("[mollie-saas-subscribe]", e);
+    return json(500, { success: false, error: e instanceof Error ? e.message : "Erreur interne" });
+  }
+});

--- a/supabase/functions/mollie-saas-subscribe/index.ts
+++ b/supabase/functions/mollie-saas-subscribe/index.ts
@@ -92,7 +92,20 @@ serve(async (req) => {
     // ── Body ──
     const { plan, iban, accountHolder, bic } = await req.json();
     const planId = String(plan || "").toLowerCase();
-    const priceCents = PLAN_PRICE_CENTS[planId];
+
+    // Prix depuis la table éditable saas_plans (source de vérité, modifiable
+    // par le super_admin). Repli sur la constante si la ligne est absente.
+    let priceCents: number | undefined;
+    const { data: planRow } = await admin
+      .from("saas_plans")
+      .select("price_cents, is_active")
+      .eq("plan_id", planId)
+      .maybeSingle();
+    if (planRow && planRow.is_active !== false) {
+      priceCents = planRow.price_cents as number;
+    } else {
+      priceCents = PLAN_PRICE_CENTS[planId];
+    }
     if (!priceCents) return json(400, { error: "Plan invalide" });
     if (!iban || !accountHolder) {
       return json(400, { error: "iban et accountHolder sont requis" });

--- a/supabase/functions/mollie-saas-subscribe/index.ts
+++ b/supabase/functions/mollie-saas-subscribe/index.ts
@@ -114,10 +114,40 @@ serve(async (req) => {
     // ── Company actuelle ──
     const { data: company } = await admin
       .from("companies")
-      .select("id, name, mollie_customer_id")
+      .select("id, name, mollie_customer_id, modules_enabled")
       .eq("id", companyId)
       .single();
     if (!company) return json(404, { error: "Entreprise introuvable" });
+
+    // ── Tarification HYBRIDE : base du plan + add-ons modules ──
+    // Add-on = module activé par le tenant, NI core NI inclus dans le plan,
+    // facturé au tarif du tier (modules.price_starter/pro/business).
+    const tierColumn =
+      planId === "pro" ? "price_pro" : planId === "business" ? "price_business" : "price_starter";
+
+    const enabled: string[] = Array.isArray(company.modules_enabled) ? company.modules_enabled : [];
+
+    const { data: included } = await admin
+      .from("plan_modules")
+      .select("module_slug")
+      .eq("plan_id", planId);
+    const includedSet = new Set((included ?? []).map((r: any) => r.module_slug));
+
+    let addOnCents = 0;
+    if (enabled.length > 0) {
+      const { data: mods } = await admin
+        .from("modules")
+        .select(`slug, is_core, ${tierColumn}`)
+        .in("slug", enabled);
+      for (const m of mods ?? []) {
+        if ((m as any).is_core) continue;
+        if (includedSet.has((m as any).slug)) continue;
+        const euros = Number((m as any)[tierColumn] ?? 0);
+        if (euros > 0) addOnCents += Math.round(euros * 100);
+      }
+    }
+
+    const totalCents = priceCents + addOnCents;
 
     const email = user.email ?? `billing+${companyId}@leazr.co`;
 
@@ -140,8 +170,8 @@ serve(async (req) => {
       ...(bic ? { consumerBic: bic } : {}),
     });
 
-    // 3) Subscription mensuelle au tarif du plan
-    const value = (priceCents / 100).toFixed(2);
+    // 3) Subscription mensuelle = base du plan + add-ons modules
+    const value = (totalCents / 100).toFixed(2);
     const webhookUrl = `${supabaseUrl}/functions/v1/mollie-webhook`;
     const subscription = await mollie(`/customers/${customerId}/subscriptions`, apiKey, "POST", {
       amount: { currency: "EUR", value },

--- a/supabase/functions/mollie-webhook/index.ts
+++ b/supabase/functions/mollie-webhook/index.ts
@@ -68,6 +68,41 @@ serve(async (req) => {
     const contractId = metadata.contract_id;
     const companyId = metadata.company_id;
 
+    // ── SaaS subscription payments (facturation A : Leazr → entreprise) ──
+    // These carry kind=saas_subscription + company_id (no contract_id). A
+    // successful recurring payment keeps the tenant active and extends the
+    // paid-through date by one month.
+    if (metadata.kind === "saas_subscription" && companyId) {
+      await supabase.from("mollie_payment_events").insert({
+        payment_id: paymentId,
+        company_id: companyId,
+        status: payment.status,
+        amount: parseFloat(payment.amount?.value || "0"),
+        currency: payment.amount?.currency || "EUR",
+        metadata: payment,
+        created_at: new Date().toISOString(),
+      });
+
+      if (payment.status === "paid") {
+        const paidThrough = new Date();
+        paidThrough.setMonth(paidThrough.getMonth() + 1);
+        await supabase
+          .from("companies")
+          .update({
+            account_status: "active",
+            subscription_ends_at: paidThrough.toISOString(),
+            ...(metadata.plan ? { plan: String(metadata.plan).toLowerCase() } : {}),
+          })
+          .eq("id", companyId);
+        console.log(`[Mollie Webhook] SaaS subscription paid for company ${companyId}`);
+      } else {
+        // failed / expired / canceled : on log seulement (pas de coupure dure
+        // sur un échec ponctuel ; la relance Mollie + le suivi admin gèrent).
+        console.log(`[Mollie Webhook] SaaS subscription ${payment.status} for company ${companyId}`);
+      }
+      return new Response("OK", { status: 200 });
+    }
+
     if (!contractId) {
       console.log("[Mollie Webhook] No contract_id in metadata, skipping");
       return new Response("OK", { status: 200 });

--- a/supabase/migrations/20260607130000_saas_mollie_subscription.sql
+++ b/supabase/migrations/20260607130000_saas_mollie_subscription.sql
@@ -1,0 +1,54 @@
+-- SaaS billing via Mollie (abonnement Leazr → entreprises clientes).
+-- Ajoute les colonnes Mollie au niveau COMPANY (jusqu'ici les colonnes mollie_*
+-- n'existaient que sur contracts, pour la collecte leasing — facturation B).
+
+ALTER TABLE public.companies
+  ADD COLUMN IF NOT EXISTS mollie_customer_id     text,
+  ADD COLUMN IF NOT EXISTS mollie_mandate_id      text,
+  ADD COLUMN IF NOT EXISTS mollie_subscription_id text,
+  ADD COLUMN IF NOT EXISTS subscription_started_at timestamptz;
+
+COMMENT ON COLUMN public.companies.mollie_subscription_id IS
+  'ID de la subscription Mollie pour l''abonnement SaaS de cette entreprise (facturation A).';
+
+-- ───────────────────────────────────────────────────────────────────────────
+-- Expiration automatique des essais (blocage DOUX : on bascule simplement le
+-- statut vers 'expired'. L''app passe alors le tenant en lecture seule + bandeau
+-- d''upgrade ; aucune donnée n''est supprimée).
+-- Une company en essai dont trial_ends_at est dépassé ET qui n''a pas d''abonnement
+-- actif (pas de mollie_subscription_id) passe 'trial' → 'expired'.
+-- ───────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.expire_overdue_trials()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $$
+DECLARE
+  affected integer;
+BEGIN
+  UPDATE public.companies
+     SET account_status = 'expired'
+   WHERE account_status = 'trial'
+     AND trial_ends_at IS NOT NULL
+     AND trial_ends_at < now()
+     AND (mollie_subscription_id IS NULL OR mollie_subscription_id = '');
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  RETURN affected;
+END;
+$$;
+
+-- Planification quotidienne (03:17 UTC) si pg_cron est disponible.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    PERFORM cron.unschedule('expire-overdue-trials')
+      WHERE EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'expire-overdue-trials');
+    PERFORM cron.schedule(
+      'expire-overdue-trials',
+      '17 3 * * *',
+      $cron$ SELECT public.expire_overdue_trials(); $cron$
+    );
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260607140000_saas_plans_table.sql
+++ b/supabase/migrations/20260607140000_saas_plans_table.sql
@@ -1,0 +1,62 @@
+-- Politique tarifaire SaaS éditable depuis le SaaS admin.
+-- Jusqu'ici la grille était une constante figée (src/config/saasPlans.ts).
+-- On la persiste en DB pour que le super_admin plateforme puisse l'éditer
+-- (prix, nom, limites, features) sans redéploiement. Le fichier de config reste
+-- le fallback typé / valeurs par défaut.
+
+CREATE TABLE IF NOT EXISTS public.saas_plans (
+  id          uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id     text NOT NULL UNIQUE,                 -- 'starter' | 'pro' | 'business'
+  name        text NOT NULL,
+  price_cents integer NOT NULL CHECK (price_cents >= 0),
+  description text NOT NULL DEFAULT '',
+  features    jsonb NOT NULL DEFAULT '[]'::jsonb,   -- string[]
+  max_users   integer NOT NULL DEFAULT -1,          -- -1 = illimité
+  max_modules integer NOT NULL DEFAULT -1,          -- -1 = illimité
+  popular     boolean NOT NULL DEFAULT false,
+  sort_order  integer NOT NULL DEFAULT 0,
+  is_active   boolean NOT NULL DEFAULT true,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Seed des 3 plans officiels (79 / 129 / 199 €).
+INSERT INTO public.saas_plans (plan_id, name, price_cents, description, features, max_users, max_modules, popular, sort_order)
+VALUES
+  ('starter',  'Starter',  7900,  'Pour débuter',
+     '["1 utilisateur","1 module","Support par email"]'::jsonb, 1, 1, false, 1),
+  ('pro',      'Pro',      12900, 'Pour grandir',
+     '["5 utilisateurs","3 modules","Support prioritaire"]'::jsonb, 5, 3, true, 2),
+  ('business', 'Business', 19900, 'Pour l''entreprise',
+     '["10 utilisateurs","Tous les modules","Support dédié"]'::jsonb, 10, -1, false, 3)
+ON CONFLICT (plan_id) DO NOTHING;
+
+-- updated_at auto
+CREATE OR REPLACE FUNCTION public.touch_saas_plans_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_saas_plans_updated_at ON public.saas_plans;
+CREATE TRIGGER trg_saas_plans_updated_at
+  BEFORE UPDATE ON public.saas_plans
+  FOR EACH ROW EXECUTE FUNCTION public.touch_saas_plans_updated_at();
+
+-- RLS : la grille tarifaire est une info publique (pages marketing, écran
+-- d'abonnement) → lecture pour tous. Écriture réservée au super_admin plateforme.
+ALTER TABLE public.saas_plans ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS saas_plans_public_read ON public.saas_plans;
+CREATE POLICY saas_plans_public_read
+  ON public.saas_plans FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS saas_plans_admin_write ON public.saas_plans;
+CREATE POLICY saas_plans_admin_write
+  ON public.saas_plans FOR ALL
+  TO authenticated
+  USING (public.is_saas_admin())
+  WITH CHECK (public.is_saas_admin());

--- a/supabase/migrations/20260607150000_plan_modules_link.sql
+++ b/supabase/migrations/20260607150000_plan_modules_link.sql
@@ -1,0 +1,65 @@
+-- Lie la politique tarifaire aux modules Leazr (modèle HYBRIDE) :
+--   • chaque plan INCLUT un socle de modules (table plan_modules),
+--   • les modules supplémentaires activés sont des ADD-ONS payants au tarif du
+--     tier (modules.price_starter/pro/business).
+-- Les modules « core » (modules.is_core) sont inclus partout, implicitement.
+
+-- 1) S'assurer que les colonnes de prix par tier existent (en euros).
+ALTER TABLE public.modules
+  ADD COLUMN IF NOT EXISTS price_starter  numeric NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS price_pro      numeric NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS price_business numeric NOT NULL DEFAULT 0;
+
+-- 2) Table de liaison plan ↔ modules inclus.
+CREATE TABLE IF NOT EXISTS public.plan_modules (
+  plan_id     text NOT NULL,                       -- 'starter' | 'pro' | 'business'
+  module_slug text NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (plan_id, module_slug)
+);
+
+-- 3) Socle inclus par défaut (l'admin pourra éditer ensuite).
+--    Starter : core seulement · Pro : core + offers/invoicing/chat ·
+--    Business : tout le catalogue connu.
+INSERT INTO public.plan_modules (plan_id, module_slug) VALUES
+  ('starter','calculator'),('starter','catalog'),('starter','crm'),
+  ('pro','calculator'),('pro','catalog'),('pro','crm'),
+  ('pro','offers'),('pro','invoicing'),('pro','chat'),
+  ('business','calculator'),('business','catalog'),('business','crm'),
+  ('business','offers'),('business','contracts'),('business','invoicing'),
+  ('business','chat'),('business','equipment'),('business','public_catalog'),
+  ('business','ai_assistant'),('business','fleet_generator'),('business','support')
+ON CONFLICT (plan_id, module_slug) DO NOTHING;
+
+-- 4) RLS : grille publique en lecture, écriture réservée au super_admin.
+ALTER TABLE public.plan_modules ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS plan_modules_public_read ON public.plan_modules;
+CREATE POLICY plan_modules_public_read
+  ON public.plan_modules FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS plan_modules_admin_write ON public.plan_modules;
+CREATE POLICY plan_modules_admin_write
+  ON public.plan_modules FOR ALL
+  TO authenticated
+  USING (public.is_saas_admin())
+  WITH CHECK (public.is_saas_admin());
+
+-- 5) Écriture des modules (catalogue global) réservée au super_admin également.
+--    (La table modules n'avait pas de policy d'écriture explicite côté admin.)
+ALTER TABLE public.modules ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS modules_public_read ON public.modules;
+CREATE POLICY modules_public_read
+  ON public.modules FOR SELECT
+  TO anon, authenticated
+  USING (true);
+
+DROP POLICY IF EXISTS modules_admin_write ON public.modules;
+CREATE POLICY modules_admin_write
+  ON public.modules FOR ALL
+  TO authenticated
+  USING (public.is_saas_admin())
+  WITH CHECK (public.is_saas_admin());


### PR DESCRIPTION
Construit le flux d'abonnement SaaS complet (Leazr → entreprises clientes) via Mollie, avec grille tarifaire éditable depuis le SaaS admin et liaison hybride aux modules.

## Contenu
- **Grille unique éditable** : table `saas_plans` (79/129/199), `useSaasPlans`, éditeur dans le SaaS admin. Supprime les 4 grilles contradictoires.
- **Tarification ↔ modules (hybride)** : table `plan_modules` (socle inclus/plan) + `modules.price_*` (add-ons par tier). Éditeur de modules + cases « inclus » par plan.
- **Mollie** : `mollie-saas-subscribe` (customer + mandat SEPA + subscription au montant base+add-ons) ; `mollie-webhook` traite les paiements d'abonnement.
- **Trial blocage doux** : `expire_overdue_trials()` (pg_cron) + `SubscriptionBanner` + page tenant `/settings/subscription` (base + add-ons + total).

## ⚠️ Checklist AVANT merge/déploiement (touche de l'argent réel)
1. **Appliquer les 3 migrations** (`20260607130000`, `140000`, `150000`) via le **SQL editor Supabase** — PAS `supabase db push` (historique désynchronisé : ~15 migrations déjà en prod non trackées, un push les rejouerait).
2. **Configurer le secret `MOLLIE_API_KEY`** (clé Organisation Mollie).
3. **Tester en SANDBOX Mollie** le flux souscription → webhook → activation.
4. Vérifier qu'aucun tenant réel n'a `account_status='expired'` ou un trial dépassé qui afficherait le bandeau « lecture seule » de façon inattendue.

## Non couvert (à suivre)
- MAJ du montant Mollie des abonnés existants quand ils changent de modules/plan.
- Débrancher les edge functions Stripe mortes (create-checkout/check-subscription/customer-portal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)