### PR TITLE
White-label : dé-hardcoder iTakecare du PDF d'offre

### DIFF
--- a/src/components/offers/CommercialOffer.tsx
+++ b/src/components/offers/CommercialOffer.tsx
@@ -14,6 +14,13 @@ interface CommercialOfferProps {
   clientAddress?: string;
   companyLogo?: string | null;
   companyName?: string;
+  // Coordonnées de l'entreprise émettrice (white-label, par tenant)
+  companyAddress?: string;
+  companyCity?: string;
+  companyPostalCode?: string;
+  companyEmail?: string;
+  companyPhone?: string;
+  companyVatNumber?: string;
   validityDays?: number;
   
   // Équipements
@@ -218,7 +225,13 @@ const CommercialOffer: React.FC<CommercialOfferProps> = ({
   clientCompany,
   clientAddress,
   companyLogo,
-  companyName = 'iTakecare',
+  companyName = '',
+  companyAddress = '',
+  companyCity = '',
+  companyPostalCode = '',
+  companyEmail = '',
+  companyPhone = '',
+  companyVatNumber = '',
   validityDays = 10,
   equipment = [],
   externalServices = [],
@@ -307,9 +320,13 @@ const CommercialOffer: React.FC<CommercialOfferProps> = ({
                 )}
               </div>
               <div className="company-info">
-                <p>Avenue Général Michel 1E, 6000 Charleroi</p>
-                <p>hello@itakecare.be | +32 71 49 16 85</p>
-                <p>TVA : BE0795.642.894</p>
+                {(companyAddress || companyPostalCode || companyCity) && (
+                  <p>{[companyAddress, [companyPostalCode, companyCity].filter(Boolean).join(' ')].filter(Boolean).join(', ')}</p>
+                )}
+                {(companyEmail || companyPhone) && (
+                  <p>{[companyEmail, companyPhone].filter(Boolean).join(' | ')}</p>
+                )}
+                {companyVatNumber && <p>TVA : {companyVatNumber}</p>}
               </div>
             </div>
             
@@ -1557,7 +1574,7 @@ const CommercialOffer: React.FC<CommercialOfferProps> = ({
               </svg>
             </div>
             <h3 className="contact-title">Email</h3>
-            <a href="mailto:hello@itakecare.be" className="contact-link">hello@itakecare.be</a>
+            <a href={`mailto:${companyEmail}`} className="contact-link">{companyEmail}</a>
           </div>
 
           <div className="contact-card">
@@ -1567,7 +1584,7 @@ const CommercialOffer: React.FC<CommercialOfferProps> = ({
               </svg>
             </div>
             <h3 className="contact-title">Téléphone</h3>
-            <a href="tel:+3271491685" className="contact-link">+32 71 49 16 85</a>
+            <a href={`tel:${companyPhone.replace(/\s+/g, '')}`} className="contact-link">{companyPhone}</a>
           </div>
         </div>
 
@@ -1580,14 +1597,17 @@ const CommercialOffer: React.FC<CommercialOfferProps> = ({
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
               </svg>
             </div>
-            <span className="signature-text">L'équipe iTakecare</span>
+            <span className="signature-text">L'équipe {companyName}</span>
           </div>
           <p className="signature-date">{new Date().toLocaleDateString('fr-FR')}</p>
         </div>
 
         {/* Footer */}
         <div className="page-footer">
-          <p>Avenue Général Michel 1E, 6000 Charleroi • TVA : BE0795.642.894</p>
+          <p>{[
+            [companyAddress, [companyPostalCode, companyCity].filter(Boolean).join(' ')].filter(Boolean).join(', '),
+            companyVatNumber ? `TVA : ${companyVatNumber}` : '',
+          ].filter(Boolean).join(' • ')}</p>
         </div>
       </div>
     </div>

--- a/src/pages/offers/OfferPrintView.tsx
+++ b/src/pages/offers/OfferPrintView.tsx
@@ -1,15 +1,26 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { ArrowLeft, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import CommercialOffer from '@/components/offers/CommercialOffer';
 import { useOfferDetail } from '@/hooks/offers/useOfferDetail';
+import {
+  fetchOfferCompanyBranding,
+  type OfferCompanyBranding,
+} from '@/services/offers/offerCompanyBranding';
 import { toast } from 'sonner';
 
 const OfferPrintView: React.FC = () => {
   const { offerId } = useParams<{ offerId: string }>();
   const navigate = useNavigate();
   const { offer, loading, error } = useOfferDetail(offerId || '');
+  const [branding, setBranding] = useState<OfferCompanyBranding | null>(null);
+
+  useEffect(() => {
+    const companyId = (offer as any)?.company_id || (offer as any)?.companies?.id;
+    if (!companyId) return;
+    fetchOfferCompanyBranding(companyId).then(setBranding);
+  }, [offer]);
 
   if (loading) {
     return (
@@ -65,6 +76,7 @@ const OfferPrintView: React.FC = () => {
 
       {/* Composant d'offre */}
       <CommercialOffer
+        {...(branding ?? {})}
         offerNumber={offer.reference || offer.id}
         offerDate={new Date(offer.created_at).toLocaleDateString('fr-FR')}
         clientName={offer.client_name}

--- a/src/services/commercialOfferPdfService.tsx
+++ b/src/services/commercialOfferPdfService.tsx
@@ -19,6 +19,12 @@ interface CommercialOfferData {
   clientAddress: string;
   companyLogo: string | null;
   companyName: string;
+  companyAddress?: string;
+  companyCity?: string;
+  companyPostalCode?: string;
+  companyEmail?: string;
+  companyPhone?: string;
+  companyVatNumber?: string;
   showPrintButton: boolean;
   isPDFMode: boolean;
   isPurchase: boolean;
@@ -242,6 +248,13 @@ async function fetchOfferDataForCommercialOffer(offerId: string): Promise<Commer
 
     const isPurchase = (offerData as any)?.is_purchase === true;
 
+    // Branding white-label de l'entreprise émettrice (coordonnées par tenant).
+    const { data: companyCustom } = await supabase
+      .from('company_customizations')
+      .select('company_name, company_address, company_city, company_postal_code, company_email, company_phone, company_vat_number')
+      .eq('company_id', offerData.companies?.id)
+      .maybeSingle();
+
     // Acompte et mensualité ajustée
     const downPayment = offerData.down_payment || 0;
     const coefficient = offerData.coefficient || 0;
@@ -259,7 +272,13 @@ async function fetchOfferDataForCommercialOffer(offerId: string): Promise<Commer
       clientCompany: (offerData as any).client_company || '',
       clientAddress: billingAddress,
       companyLogo: companyLogoBase64,
-      companyName: offerData.companies?.name || 'iTakecare',
+      companyName: companyCustom?.company_name || offerData.companies?.name || '',
+      companyAddress: companyCustom?.company_address || '',
+      companyCity: companyCustom?.company_city || '',
+      companyPostalCode: companyCustom?.company_postal_code || '',
+      companyEmail: companyCustom?.company_email || '',
+      companyPhone: companyCustom?.company_phone || '',
+      companyVatNumber: companyCustom?.company_vat_number || '',
       showPrintButton: false,
       isPDFMode: true,
       isPurchase: isPurchase,

--- a/src/services/offers/offerCompanyBranding.ts
+++ b/src/services/offers/offerCompanyBranding.ts
@@ -1,0 +1,67 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/** Coordonnées de l'entreprise émettrice pour l'offre commerciale (white-label). */
+export interface OfferCompanyBranding {
+  companyName: string;
+  companyLogo: string | null;
+  companyAddress: string;
+  companyCity: string;
+  companyPostalCode: string;
+  companyEmail: string;
+  companyPhone: string;
+  companyVatNumber: string;
+}
+
+const EMPTY: OfferCompanyBranding = {
+  companyName: "",
+  companyLogo: null,
+  companyAddress: "",
+  companyCity: "",
+  companyPostalCode: "",
+  companyEmail: "",
+  companyPhone: "",
+  companyVatNumber: "",
+};
+
+/**
+ * Récupère le branding d'une entreprise depuis `company_customizations`
+ * (avec repli sur la table `companies` pour le nom/logo). Aucune valeur
+ * codée en dur — chaque tenant affiche SES propres coordonnées.
+ */
+export const fetchOfferCompanyBranding = async (
+  companyId: string | null | undefined,
+): Promise<OfferCompanyBranding> => {
+  if (!companyId) return EMPTY;
+
+  const { data: c } = await supabase
+    .from("company_customizations")
+    .select(
+      "company_name, logo_url, company_address, company_city, company_postal_code, company_email, company_phone, company_vat_number",
+    )
+    .eq("company_id", companyId)
+    .maybeSingle();
+
+  // Repli nom/logo depuis companies si les customizations sont incomplètes.
+  let fallbackName = "";
+  let fallbackLogo: string | null = null;
+  if (!c?.company_name || !c?.logo_url) {
+    const { data: comp } = await supabase
+      .from("companies")
+      .select("name, logo_url")
+      .eq("id", companyId)
+      .maybeSingle();
+    fallbackName = comp?.name ?? "";
+    fallbackLogo = comp?.logo_url ?? null;
+  }
+
+  return {
+    companyName: c?.company_name || fallbackName,
+    companyLogo: c?.logo_url || fallbackLogo,
+    companyAddress: c?.company_address || "",
+    companyCity: c?.company_city || "",
+    companyPostalCode: c?.company_postal_code || "",
+    companyEmail: c?.company_email || "",
+    companyPhone: c?.company_phone || "",
+    companyVatNumber: c?.company_vat_number || "",
+  };
+};


### PR DESCRIPTION
Les coordonnées (adresse, TVA, email, téléphone, signature) étaient codées en dur « iTakecare » dans le PDF d'offre commerciale. Elles viennent désormais de `company_customizations` par tenant.

- `CommercialOffer` : nouvelles props société + rendu depuis les props (aucun repli iTakecare).
- `offerCompanyBranding` : helper de lecture du branding tenant.
- `OfferPrintView` + `commercialOfferPdfService` : récupèrent et passent le branding.

iTakecare a déjà ses coordonnées en base → **aucun changement visible** pour eux ; chaque tenant affiche les siennes.

**Reste** : white-labeler les templates email (plus complexe — domaines d'envoi Resend par tenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)