### PR TITLE
Admin : clé API Mollie configurable depuis le SaaS admin

### DIFF
--- a/src/components/saas/PaymentSettings.tsx
+++ b/src/components/saas/PaymentSettings.tsx
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from "react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle2, AlertCircle, Loader2, CreditCard } from "lucide-react";
+import { toast } from "sonner";
+import {
+  setPlatformSecret,
+  getPlatformSecretStatus,
+} from "@/services/platformSecretsService";
+
+/**
+ * Paramètres de paiement SaaS : saisie de la clé API Mollie (Organisation).
+ * La clé est stockée côté serveur (jamais relue par le navigateur) et utilisée
+ * par les edge functions Mollie (abonnement SaaS + collecte SEPA).
+ */
+const PaymentSettings: React.FC = () => {
+  const [mollieKey, setMollieKey] = useState("");
+  const [configured, setConfigured] = useState<boolean | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  const loadStatus = async () => {
+    setLoading(true);
+    const status = await getPlatformSecretStatus(["MOLLIE_API_KEY"]);
+    setConfigured(!!status.MOLLIE_API_KEY);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    loadStatus();
+  }, []);
+
+  const handleSave = async () => {
+    if (!mollieKey.trim()) {
+      toast.error("Saisissez une clé API Mollie.");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await setPlatformSecret("MOLLIE_API_KEY", mollieKey.trim());
+      if (res.success) {
+        toast.success("Clé Mollie enregistrée.");
+        setMollieKey("");
+        await loadStatus();
+      } else {
+        toast.error(res.error || "Échec de l'enregistrement.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <CreditCard className="h-5 w-5" />
+          <CardTitle>Mollie</CardTitle>
+          {!loading && configured !== null && (
+            configured ? (
+              <Badge variant="outline" className="gap-1 bg-green-50 text-green-700 border-green-200">
+                <CheckCircle2 className="h-3 w-3" /> Configurée
+              </Badge>
+            ) : (
+              <Badge variant="outline" className="gap-1 bg-amber-50 text-amber-700 border-amber-200">
+                <AlertCircle className="h-3 w-3" /> Non configurée
+              </Badge>
+            )
+          )}
+        </div>
+        <CardDescription>
+          Clé API Mollie (Organisation) utilisée pour les abonnements SaaS et la
+          collecte SEPA. La clé est stockée de façon sécurisée côté serveur et
+          n'est jamais réaffichée.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="space-y-1.5 max-w-xl">
+          <Label htmlFor="mollie-key">
+            {configured ? "Remplacer la clé API Mollie" : "Clé API Mollie"}
+          </Label>
+          <Input
+            id="mollie-key"
+            type="password"
+            autoComplete="off"
+            value={mollieKey}
+            onChange={(e) => setMollieKey(e.target.value)}
+            placeholder="live_xxxxxxxx ou test_xxxxxxxx"
+          />
+          <p className="text-xs text-muted-foreground">
+            Clé « Live » pour la production, « Test » pour le sandbox Mollie.
+          </p>
+        </div>
+        <Button onClick={handleSave} disabled={saving || loading}>
+          {saving && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+          {configured ? "Mettre à jour la clé" : "Enregistrer la clé"}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PaymentSettings;

--- a/src/components/saas/SaaSSettingsManager.tsx
+++ b/src/components/saas/SaaSSettingsManager.tsx
@@ -21,6 +21,7 @@ import PlatformIdentitySettings from "./PlatformIdentitySettings";
 import { PostalCodeImport } from "@/components/admin/PostalCodeImport";
 import SaaSModulesManager from "./SaaSModulesManager";
 import BrokerManagement from "./BrokerManagement";
+import PaymentSettings from "./PaymentSettings";
 import { Building } from "lucide-react";
 
 const SaaSSettingsManager = () => {
@@ -32,6 +33,7 @@ const SaaSSettingsManager = () => {
     { id: "modules", label: "Modules", icon: Layers },
     { id: "plans", label: "Plans & Tarifs", icon: Package },
     { id: "brokers", label: "Brokers", icon: Building },
+    { id: "payment", label: "Paiement", icon: CreditCard },
     { id: "postal-codes", label: "Codes Postaux", icon: MapPin },
   ];
 
@@ -49,7 +51,7 @@ const SaaSSettingsManager = () => {
       </div>
 
       <Tabs value={activeTab} onValueChange={setActiveTab}>
-        <TabsList className="grid w-full grid-cols-6">
+        <TabsList className="grid w-full grid-cols-7">
           {tabs.map((tab) => {
             const IconComponent = tab.icon;
             return (
@@ -100,6 +102,10 @@ const SaaSSettingsManager = () => {
 
         <TabsContent value="brokers" className="space-y-6">
           <BrokerManagement />
+        </TabsContent>
+
+        <TabsContent value="payment" className="space-y-6">
+          <PaymentSettings />
         </TabsContent>
 
         <TabsContent value="postal-codes" className="space-y-6">

--- a/src/services/platformSecretsService.ts
+++ b/src/services/platformSecretsService.ts
@@ -1,0 +1,29 @@
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Secrets plateforme (clé Mollie, etc.) gérés via l'edge function
+ * `platform-secret` (réservée au super_admin). La VALEUR n'est jamais
+ * renvoyée au navigateur — uniquement un statut "configuré ?".
+ */
+
+export const setPlatformSecret = async (
+  key: string,
+  value: string,
+): Promise<{ success: boolean; error?: string }> => {
+  const { data, error } = await supabase.functions.invoke("platform-secret", {
+    body: { action: "set", key, value },
+  });
+  if (error) return { success: false, error: error.message };
+  if (!data?.success) return { success: false, error: data?.error || "Échec" };
+  return { success: true };
+};
+
+export const getPlatformSecretStatus = async (
+  keys: string[],
+): Promise<Record<string, boolean>> => {
+  const { data, error } = await supabase.functions.invoke("platform-secret", {
+    body: { action: "status", keys },
+  });
+  if (error || !data?.status) return {};
+  return data.status as Record<string, boolean>;
+};

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -289,3 +289,7 @@ verify_jwt = false
 [functions.mollie-saas-subscribe]
 # Authenticated SaaS subscription (admin). Does its own auth + company scoping.
 verify_jwt = true
+
+[functions.platform-secret]
+# SaaS admin secrets (super_admin only). Does its own auth.
+verify_jwt = true

--- a/supabase/functions/_shared/getMollieKey.ts
+++ b/supabase/functions/_shared/getMollieKey.ts
@@ -1,0 +1,27 @@
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+/**
+ * Récupère la clé API Mollie. Priorité à la valeur configurée depuis le SaaS
+ * admin (table platform_secrets, lue en service_role), avec repli sur la
+ * variable d'environnement MOLLIE_API_KEY pour rétro-compatibilité.
+ */
+export async function getMollieApiKey(): Promise<string | null> {
+  try {
+    const url = Deno.env.get("SUPABASE_URL");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    if (url && serviceKey) {
+      const admin = createClient(url, serviceKey, {
+        auth: { autoRefreshToken: false, persistSession: false },
+      });
+      const { data } = await admin
+        .from("platform_secrets")
+        .select("value")
+        .eq("key", "MOLLIE_API_KEY")
+        .maybeSingle();
+      if (data?.value) return data.value as string;
+    }
+  } catch (_) {
+    // table absente / erreur réseau → on retombe sur l'env
+  }
+  return Deno.env.get("MOLLIE_API_KEY") || null;
+}

--- a/supabase/functions/mollie-saas-subscribe/index.ts
+++ b/supabase/functions/mollie-saas-subscribe/index.ts
@@ -15,6 +15,7 @@
  */
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getMollieApiKey } from "../_shared/getMollieKey.ts";
 
 const MOLLIE_API_URL = "https://api.mollie.com/v2";
 
@@ -58,8 +59,8 @@ serve(async (req) => {
   if (req.method !== "POST") return json(405, { error: "Method not allowed" });
 
   try {
-    const apiKey = Deno.env.get("MOLLIE_API_KEY");
-    if (!apiKey) return json(500, { error: "MOLLIE_API_KEY non configurée" });
+    const apiKey = await getMollieApiKey();
+    if (!apiKey) return json(500, { error: "Clé API Mollie non configurée (SaaS admin → Paiement)" });
 
     const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
     const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;

--- a/supabase/functions/mollie-sepa/index.ts
+++ b/supabase/functions/mollie-sepa/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getMollieApiKey } from "../_shared/getMollieKey.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -39,9 +40,9 @@ async function mollieRequest(
   method: "GET" | "POST" | "DELETE" = "GET",
   body?: Record<string, unknown>
 ): Promise<{ success: boolean; data?: unknown; error?: string; status?: number }> {
-  const apiKey = Deno.env.get("MOLLIE_API_KEY");
+  const apiKey = await getMollieApiKey();
   if (!apiKey) {
-    return { success: false, error: "MOLLIE_API_KEY non configurée" };
+    return { success: false, error: "Clé API Mollie non configurée (SaaS admin → Paiement)" };
   }
 
   try {

--- a/supabase/functions/mollie-webhook/index.ts
+++ b/supabase/functions/mollie-webhook/index.ts
@@ -1,5 +1,6 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { getMollieApiKey } from "../_shared/getMollieKey.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -38,9 +39,9 @@ serve(async (req) => {
     console.log(`[Mollie Webhook] Received notification for: ${paymentId}`);
 
     // Fetch payment details from Mollie
-    const apiKey = Deno.env.get("MOLLIE_API_KEY");
+    const apiKey = await getMollieApiKey();
     if (!apiKey) {
-      console.error("[Mollie Webhook] MOLLIE_API_KEY not configured");
+      console.error("[Mollie Webhook] Clé API Mollie non configurée");
       return new Response("OK", { status: 200 });
     }
 

--- a/supabase/functions/platform-secret/index.ts
+++ b/supabase/functions/platform-secret/index.ts
@@ -1,0 +1,80 @@
+/**
+ * platform-secret
+ *
+ * Gère les secrets plateforme (table platform_secrets) depuis le SaaS admin.
+ * Réservé au super_admin. Le navigateur ne récupère JAMAIS la valeur d'un
+ * secret — seulement un statut "configuré / non configuré".
+ *
+ *  POST { action: "set",    key, value }   → enregistre/écrase un secret
+ *  POST { action: "status", keys: [...] }  → { [key]: boolean } (configuré ?)
+ */
+import { requireElevatedAccess } from "../_shared/security.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+
+// Clés autorisées à être gérées via cette interface.
+const ALLOWED_KEYS = new Set<string>(["MOLLIE_API_KEY"]);
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
+  if (req.method !== "POST") return json(405, { error: "Method not allowed" });
+
+  // Auth : super_admin uniquement (pas de raccourci service_role inter-tenant ici).
+  const access = await requireElevatedAccess(req, corsHeaders, {
+    allowedRoles: ["super_admin"],
+    allowServiceRole: false,
+  });
+  if (!access.ok) return access.response;
+  const { supabaseAdmin, userId } = access.context;
+
+  let body: any;
+  try {
+    body = await req.json();
+  } catch {
+    return json(400, { error: "Corps JSON invalide" });
+  }
+
+  const action = body?.action;
+
+  if (action === "status") {
+    const keys: string[] = Array.isArray(body.keys) ? body.keys : [];
+    const { data } = await supabaseAdmin
+      .from("platform_secrets")
+      .select("key, value")
+      .in("key", keys);
+    const status: Record<string, boolean> = {};
+    for (const k of keys) status[k] = false;
+    for (const row of data ?? []) {
+      status[(row as any).key] = !!(row as any).value;
+    }
+    return json(200, { status });
+  }
+
+  if (action === "set") {
+    const key = String(body.key || "");
+    const value = String(body.value ?? "");
+    if (!ALLOWED_KEYS.has(key)) return json(400, { error: "Clé non autorisée" });
+    if (!value.trim()) return json(400, { error: "Valeur vide" });
+
+    const { error } = await supabaseAdmin
+      .from("platform_secrets")
+      .upsert(
+        { key, value: value.trim(), updated_at: new Date().toISOString(), updated_by: userId },
+        { onConflict: "key" },
+      );
+    if (error) return json(500, { error: error.message });
+    return json(200, { success: true });
+  }
+
+  return json(400, { error: "Action inconnue" });
+});

--- a/supabase/migrations/20260608090000_platform_secrets.sql
+++ b/supabase/migrations/20260608090000_platform_secrets.sql
@@ -1,0 +1,18 @@
+-- Secrets plateforme éditables depuis le SaaS admin (ex: clé API Mollie).
+-- Stockés en DB pour être configurables par le super_admin sans redéploiement.
+-- SÉCURITÉ : table accessible UNIQUEMENT au service_role (edge functions).
+-- Le navigateur ne peut JAMAIS lire la valeur — RLS activée sans aucune policy,
+-- et les GRANTs retirés pour anon/authenticated. La lecture/écriture passe
+-- exclusivement par des edge functions (super_admin pour écrire).
+
+CREATE TABLE IF NOT EXISTS public.platform_secrets (
+  key        text PRIMARY KEY,
+  value      text NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by uuid
+);
+
+ALTER TABLE public.platform_secrets ENABLE ROW LEVEL SECURITY;
+-- Aucune policy => seul le service_role (qui bypasse la RLS) y accède.
+
+REVOKE ALL ON public.platform_secrets FROM anon, authenticated;


### PR DESCRIPTION
Onglet « Paiement » dans la config SaaS admin pour saisir la clé API Mollie sans redéploiement.

- Table `platform_secrets` (service-role only, valeur jamais exposée au navigateur) — **migration déjà appliquée en prod**.
- Edge function `platform-secret` (super_admin) : set / status.
- Helper `_shared/getMollieKey` : DB puis fallback env. `mollie-saas-subscribe`/`mollie-webhook`/`mollie-sepa` l'utilisent.
- UI `PaymentSettings` : input password (write-only) + badge configuré/non configuré.

Après merge+déploiement : SaaS admin → Configuration → onglet Paiement → coller la clé Mollie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)